### PR TITLE
Apply date filters correctly when using SearchParameters

### DIFF
--- a/src/xai_sdk/search.py
+++ b/src/xai_sdk/search.py
@@ -66,9 +66,17 @@ class SearchParameters:
 
     def _to_proto(self) -> chat_pb2.SearchParameters:
         """Converts the search parameters to a chat_pb2.SearchParameters proto."""
+        from_date_pb = Timestamp()
+        to_date_pb = Timestamp()
+
+        if self.from_date is not None:
+            from_date_pb.FromDatetime(self.from_date)
+        if self.to_date is not None:
+            to_date_pb.FromDatetime(self.to_date)
+
         return chat_pb2.SearchParameters(
-            from_date=Timestamp().FromDatetime(self.from_date) if self.from_date else None,
-            to_date=Timestamp().FromDatetime(self.to_date) if self.to_date else None,
+            from_date=from_date_pb if self.from_date is not None else None,
+            to_date=to_date_pb if self.to_date is not None else None,
             max_search_results=self.max_search_results,
             return_citations=self.return_citations,
             mode=self._search_mode_to_proto(self.mode),

--- a/tests/aio/chat_test.py
+++ b/tests/aio/chat_test.py
@@ -610,6 +610,12 @@ def test_chat_create_with_search_parameters(client: AsyncClient):
     from_date = datetime(2025, 1, 1, tzinfo=timezone.utc)
     to_date = datetime(2025, 1, 31, tzinfo=timezone.utc)
 
+    expected_from_date_pb = timestamp_pb2.Timestamp()
+    expected_from_date_pb.FromDatetime(from_date)
+
+    expected_to_date_pb = timestamp_pb2.Timestamp()
+    expected_to_date_pb.FromDatetime(to_date)
+
     chat = client.chat.create(
         "grok-3",
         search_parameters=SearchParameters(
@@ -635,8 +641,8 @@ def test_chat_create_with_search_parameters(client: AsyncClient):
 
     assert chat_completion_request.search_parameters == chat_pb2.SearchParameters(
         mode=chat_pb2.SearchMode.ON_SEARCH_MODE,
-        from_date=timestamp_pb2.Timestamp().FromDatetime(from_date),
-        to_date=timestamp_pb2.Timestamp().FromDatetime(to_date),
+        from_date=expected_from_date_pb,
+        to_date=expected_to_date_pb,
         sources=[
             chat_pb2.Source(web=chat_pb2.WebSource(country="UK", excluded_websites=["excluded.com"], safe_search=True)),
             chat_pb2.Source(news=chat_pb2.NewsSource(country="UK", safe_search=True)),
@@ -658,10 +664,16 @@ def test_chat_create_with_search_parameters_proto(client: AsyncClient):
     from_date = datetime(2025, 1, 1, tzinfo=timezone.utc)
     to_date = datetime(2025, 1, 31, tzinfo=timezone.utc)
 
+    expected_from_date_pb = timestamp_pb2.Timestamp()
+    expected_from_date_pb.FromDatetime(from_date)
+
+    expected_to_date_pb = timestamp_pb2.Timestamp()
+    expected_to_date_pb.FromDatetime(to_date)
+
     search_parameters_pb = chat_pb2.SearchParameters(
         mode=chat_pb2.SearchMode.ON_SEARCH_MODE,
-        from_date=timestamp_pb2.Timestamp().FromDatetime(from_date),
-        to_date=timestamp_pb2.Timestamp().FromDatetime(to_date),
+        from_date=expected_from_date_pb,
+        to_date=expected_to_date_pb,
         sources=[
             chat_pb2.Source(web=chat_pb2.WebSource(country="UK", excluded_websites=["excluded.com"], safe_search=True)),
             chat_pb2.Source(news=chat_pb2.NewsSource(country="UK", safe_search=True)),

--- a/tests/sync/chat_test.py
+++ b/tests/sync/chat_test.py
@@ -617,10 +617,16 @@ def test_chat_create_with_search_parameters(client: Client):
 
     chat_completion_request = chat.proto
 
+    expected_from_date_pb = timestamp_pb2.Timestamp()
+    expected_from_date_pb.FromDatetime(from_date)
+
+    expected_to_date_pb = timestamp_pb2.Timestamp()
+    expected_to_date_pb.FromDatetime(to_date)
+
     assert chat_completion_request.search_parameters == chat_pb2.SearchParameters(
         mode=chat_pb2.SearchMode.ON_SEARCH_MODE,
-        from_date=timestamp_pb2.Timestamp().FromDatetime(from_date),
-        to_date=timestamp_pb2.Timestamp().FromDatetime(to_date),
+        from_date=expected_from_date_pb,
+        to_date=expected_to_date_pb,
         sources=[
             chat_pb2.Source(web=chat_pb2.WebSource(country="UK", excluded_websites=["excluded.com"], safe_search=True)),
             chat_pb2.Source(news=chat_pb2.NewsSource(country="UK", safe_search=True)),
@@ -642,10 +648,16 @@ def test_chat_create_with_search_parameters_proto(client: Client):
     from_date = datetime(2025, 1, 1, tzinfo=timezone.utc)
     to_date = datetime(2025, 1, 31, tzinfo=timezone.utc)
 
+    expected_from_date_pb = timestamp_pb2.Timestamp()
+    expected_from_date_pb.FromDatetime(from_date)
+
+    expected_to_date_pb = timestamp_pb2.Timestamp()
+    expected_to_date_pb.FromDatetime(to_date)
+
     search_parameters_pb = chat_pb2.SearchParameters(
         mode=chat_pb2.SearchMode.ON_SEARCH_MODE,
-        from_date=timestamp_pb2.Timestamp().FromDatetime(from_date),
-        to_date=timestamp_pb2.Timestamp().FromDatetime(to_date),
+        from_date=expected_from_date_pb,
+        to_date=expected_to_date_pb,
         sources=[
             chat_pb2.Source(web=chat_pb2.WebSource(country="UK", excluded_websites=["excluded.com"], safe_search=True)),
             chat_pb2.Source(news=chat_pb2.NewsSource(country="UK", safe_search=True)),


### PR DESCRIPTION
- This PR fixes a bug where the `from_date` and `to_date` parameters passed by a user in `SearchParamaters` when using the live search feature had no effect and would be ignored.
- The `_to_proto` method defined on the `SearchParameters` dataclass was incorrectly converting the `datetime` objects to their proto equivalents
- This fix ensures they are indeed being converted and set correctly as proto timestamps
- Update tests to properly check for this scenario
