### PR TITLE
Bump version from v1.1.0 -> v1.2.0

### DIFF
--- a/src/xai_sdk/__about__.py
+++ b/src/xai_sdk/__about__.py
@@ -3,4 +3,4 @@
 # To change the version, do so using `uv run hatch version <new-version>`
 # or `uv run hatch version <patch|minor|major>` to bump the patch/minor/major version respectively.
 # See https://hatch.pypa.io/latest/version/#updating for more details.
-__version__ = "1.1.0"
+__version__ = "1.2.0"


### PR DESCRIPTION
Prepare for the release of version `v1.2.0` of the SDK following the addition of support for the collections API (#28) and support for the stateful chat API (#29)