### PR TITLE
Remove double await in async interceptor

### DIFF
--- a/src/xai_sdk/client.py
+++ b/src/xai_sdk/client.py
@@ -209,8 +209,7 @@ class UnaryUnaryAioInterceptor(
     async def intercept_unary_unary(self, continuation, client_call_details, request):
         """Intercepts a unary-unary RPC call."""
         new_details = client_call_details._replace(timeout=self.timeout)  # type: ignore
-        response = await continuation(new_details, request)
-        return await response
+        return await continuation(new_details, request)
 
 
 class UnaryStreamAioInterceptor(


### PR DESCRIPTION
Fixes a bug where a double await was happening in one of the async gRPC interceptors