### PR TITLE
Add context manager support and proper channel cleanup to clients

### DIFF
--- a/src/xai_sdk/aio/client.py
+++ b/src/xai_sdk/aio/client.py
@@ -34,22 +34,22 @@ class Client(BaseClient):
                 "Trying to read the xAI API key from the XAI_API_KEY environment variable but it doesn't exist."
             )
 
-        api_channel = self._make_grpc_channel(api_key, api_host, metadata, channel_options, timeout)
+        self._api_channel = self._make_grpc_channel(api_key, api_host, metadata, channel_options, timeout)
 
         # Management channel is optional, we perform further checks in the collections client
         management_api_key = management_api_key or os.getenv("XAI_MANAGEMENT_KEY")
-        management_channel = (
+        self._management_channel = (
             self._make_grpc_channel(management_api_key, management_api_host, metadata, channel_options, timeout)
             if management_api_key
             else None
         )
 
-        self.auth = auth.Client(api_channel)
-        self.chat = chat.Client(api_channel)
-        self.collections = collections.Client(api_channel, management_channel)
-        self.image = image.Client(api_channel)
-        self.models = models.Client(api_channel)
-        self.tokenize = tokenizer.Client(api_channel)
+        self.auth = auth.Client(self._api_channel)
+        self.chat = chat.Client(self._api_channel)
+        self.collections = collections.Client(self._api_channel, self._management_channel)
+        self.image = image.Client(self._api_channel)
+        self.models = models.Client(self._api_channel)
+        self.tokenize = tokenizer.Client(self._api_channel)
 
     def _make_grpc_channel(
         self,
@@ -67,3 +67,19 @@ class Client(BaseClient):
             interceptors=[UnaryUnaryAioInterceptor(timeout), UnaryStreamAioInterceptor(timeout)],  # type: ignore
         )
         return channel
+
+    async def close(self) -> None:
+        """Close method to properly clean up gRPC channels."""
+        if self._management_channel is not None:
+            await self._management_channel.close()
+
+        if self._api_channel is not None:
+            await self._api_channel.close()
+
+    async def __aenter__(self):
+        """Async context manager entry."""
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Async context manager exit with cleanup."""
+        await self.close()

--- a/src/xai_sdk/sync/client.py
+++ b/src/xai_sdk/sync/client.py
@@ -33,22 +33,22 @@ class Client(BaseClient):
             raise ValueError(
                 "Trying to read the xAI API key from the XAI_API_KEY environment variable but it doesn't exist."
             )
-        api_channel = self._make_grpc_channel(api_key, api_host, metadata, channel_options, timeout)
+        self._api_channel = self._make_grpc_channel(api_key, api_host, metadata, channel_options, timeout)
 
         # Management channel is optional, we perform further checks in the collections client
         management_api_key = management_api_key or os.getenv("XAI_MANAGEMENT_KEY")
-        management_channel = (
+        self._management_channel = (
             self._make_grpc_channel(management_api_key, management_api_host, metadata, channel_options, timeout)
             if management_api_key
             else None
         )
 
-        self.auth = auth.Client(api_channel)
-        self.chat = chat.Client(api_channel)
-        self.collections = collections.Client(api_channel, management_channel)
-        self.image = image.Client(api_channel)
-        self.models = models.Client(api_channel)
-        self.tokenize = tokenizer.Client(api_channel)
+        self.auth = auth.Client(self._api_channel)
+        self.chat = chat.Client(self._api_channel)
+        self.collections = collections.Client(self._api_channel, self._management_channel)
+        self.image = image.Client(self._api_channel)
+        self.models = models.Client(self._api_channel)
+        self.tokenize = tokenizer.Client(self._api_channel)
 
     def _make_grpc_channel(
         self,
@@ -66,3 +66,19 @@ class Client(BaseClient):
         )
         channel = grpc.intercept_channel(channel, TimeoutInterceptor(timeout))
         return channel
+
+    def close(self) -> None:
+        """Close method to properly clean up gRPC channels."""
+        if self._management_channel is not None:
+            self._management_channel.close()
+
+        if self._api_channel is not None:
+            self._api_channel.close()
+
+    def __enter__(self):
+        """Context manager entry."""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit with cleanup."""
+        self.close()


### PR DESCRIPTION
# Pull Request Title

## Checklist
- [x] I have read both the [CONTRIBUTING.md](CONTRIBUTING.md) and [Contributor License Agreement](CLA.md) documents.
- [x] I have created an issue or feature request and received approval from xAI maintainers. (minor changes like fixing typos can skip this step)
- [x] I have tested my changes locally and they pass all CI checks.
- [x] I have added necessary documentation or updated existing documentation. 

## Description
- Store gRPC channel references in sync and async clients
- Implement `__enter__`/`__exit__` for sync `Client`
- Implement `__aenter__`/`__aexit__` for async `Client`
- Add `close()` methods to properly clean up gRPC channels

## Related Issue
N/A.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please specify)