### PR TITLE
Add ability to exclude sensitive attributes for traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## [Unreleased]
 ### Added
-- New features or functionalities added to the project.
+- Add ability to exclude sensitive attributes from telemetry spans/traces via the `XAI_SDK_DISABLE_SENSITIVE_TELEMETRY_ATTRIBUTES` environment variable.
 
 ### Changed
 - Updates or modifications to existing features.
 
 ### Fixed
-- Bug fixes or corrections to existing issues.
+- Double await in `UnaryStreamAioInterceptor`
 
 ### Removed
 - Features or functionalities that have been removed.

--- a/README.md
+++ b/README.md
@@ -293,6 +293,10 @@ telemetry.setup_otlp_exporter()
 
 If you're using the xAI SDK within an application that is already using OpenTelemetry to export other traces, you may want to selectively disable xAI SDK traces only, this can be done by setting the environment variable `XAI_SDK_DISABLE_TRACING` to `1` or `true`.
 
+### Disabling Sensitive Attributes
+
+For privacy reasons, you may want to disable the collection of sensitive attributes such as user inputs and AI responses in traces. This can be done by setting the environment variable `XAI_SDK_DISABLE_SENSITIVE_TELEMETRY_ATTRIBUTES` to `1` or `true`. When enabled, traces will still be collected but without the content of messages, prompts, or responses.
+
 ## Timeouts
 
 The xAI SDK allows you to set a timeout for API requests during client initialization. This timeout applies to all RPCs and methods used with that client instance. The default timeout is 15 minutes (900 seconds).

--- a/src/xai_sdk/telemetry/__init__.py
+++ b/src/xai_sdk/telemetry/__init__.py
@@ -1,3 +1,3 @@
-from .config import Telemetry, get_tracer
+from .config import Telemetry, get_tracer, should_disable_sensitive_attributes
 
-__all__ = ["Telemetry", "get_tracer"]
+__all__ = ["Telemetry", "get_tracer", "should_disable_sensitive_attributes"]

--- a/src/xai_sdk/telemetry/config.py
+++ b/src/xai_sdk/telemetry/config.py
@@ -29,6 +29,11 @@ class Telemetry:
     - OTEL_EXPORTER_OTLP_HEADERS: Authentication headers (e.g., "Authorization=Bearer token")
     - And many others as defined in the OpenTelemetry specification
 
+    Additionally, the following xAI SDK specific environment variables are supported:
+    - XAI_SDK_DISABLE_TRACING: Disables all tracing if set to "1" or "true"
+    - XAI_SDK_DISABLE_SENSITIVE_TELEMETRY_ATTRIBUTES: Disables collection of sensitive attributes
+      (user inputs, AI responses, prompts) in traces if set to "1" or "true"
+
     Examples:
         Basic setup with console output for development:
         ```python
@@ -183,3 +188,11 @@ def get_tracer(name: str) -> otel_trace.Tracer:
     if os.getenv("XAI_SDK_DISABLE_TRACING", "0").lower() in ["1", "true"]:
         return otel_trace.NoOpTracer()
     return otel_trace.get_tracer(name)
+
+
+def should_disable_sensitive_attributes() -> bool:
+    """Check if sensitive attributes should be disabled in telemetry.
+
+    Returns True if XAI_SDK_DISABLE_SENSITIVE_TELEMETRY_ATTRIBUTES is set to "1" or "true".
+    """
+    return os.getenv("XAI_SDK_DISABLE_SENSITIVE_TELEMETRY_ATTRIBUTES", "0").lower() in ["1", "true"]

--- a/tests/sync/chat_test.py
+++ b/tests/sync/chat_test.py
@@ -620,6 +620,37 @@ def test_sample_creates_span_with_correct_attributes(mock_tracer: mock.MagicMock
 
 
 @mock.patch("xai_sdk.sync.chat.tracer")
+def test_sample_creates_span_without_sensitive_attributes_when_disabled(mock_tracer: mock.MagicMock, client: Client):
+    """Test that sensitive attributes are not included when XAI_SDK_DISABLE_SENSITIVE_TELEMETRY_ATTRIBUTES is set."""
+    mock_span = mock.MagicMock()
+    mock_tracer.start_as_current_span.return_value.__enter__.return_value = mock_span
+
+    conversation_id = "test-conversation-id"
+    chat = client.chat.create(model="grok-3", conversation_id=conversation_id)
+    chat.append(user("Hello, how are you?"))
+
+    with mock.patch.dict("os.environ", {"XAI_SDK_DISABLE_SENSITIVE_TELEMETRY_ATTRIBUTES": "1"}):
+        chat.sample()
+
+    expected_request_attributes = {
+        "gen_ai.operation.name": "chat",
+        "gen_ai.system": "xai",
+        "gen_ai.output.type": "text",
+        "gen_ai.request.model": "grok-3",
+        "server.port": 443,
+    }
+
+    mock_tracer.start_as_current_span.assert_called_once_with(
+        name="chat.sample grok-3",
+        kind=SpanKind.CLIENT,
+        attributes=expected_request_attributes,
+    )
+
+    expected_response_attributes = {}
+    mock_span.set_attributes.assert_called_once_with(expected_response_attributes)
+
+
+@mock.patch("xai_sdk.sync.chat.tracer")
 def test_sample_creates_span_with_correct_optional_attributes(mock_tracer: mock.MagicMock, client: Client):
     """Test that all possible request attributes are set when all fields are provided."""
     mock_span = mock.MagicMock()

--- a/tests/sync/image_test.py
+++ b/tests/sync/image_test.py
@@ -89,6 +89,38 @@ def test_sample_creates_span_with_correct_attributes(
 
 @mock.patch("xai_sdk.sync.image.tracer")
 @pytest.mark.parametrize("image_format", ["url", "base64"])
+def test_sample_creates_span_without_sensitive_attributes_when_disabled(
+    mock_tracer: mock.MagicMock, client: Client, image_format: ImageFormat
+):
+    """Test that sensitive attributes are not included when XAI_SDK_DISABLE_SENSITIVE_TELEMETRY_ATTRIBUTES is set."""
+    mock_span = mock.MagicMock()
+    mock_tracer.start_as_current_span.return_value.__enter__.return_value = mock_span
+
+    user = "test-user-123"
+    with mock.patch.dict("os.environ", {"XAI_SDK_DISABLE_SENSITIVE_TELEMETRY_ATTRIBUTES": "1"}):
+        client.image.sample(prompt="A beautiful sunset", model="grok-2-image", image_format=image_format, user=user)
+
+    expected_request_attributes = {
+        "gen_ai.operation.name": "generate_image",
+        "gen_ai.system": "xai",
+        "gen_ai.request.model": "grok-2-image",
+    }
+
+    mock_tracer.start_as_current_span.assert_called_once_with(
+        name="image.sample grok-2-image",
+        kind=SpanKind.CLIENT,
+        attributes=expected_request_attributes,
+    )
+
+    expected_response_attributes = {
+        "gen_ai.response.model": "grok-2-image",
+    }
+
+    mock_span.set_attributes.assert_called_once_with(expected_response_attributes)
+
+
+@mock.patch("xai_sdk.sync.image.tracer")
+@pytest.mark.parametrize("image_format", ["url", "base64"])
 def test_sample_batch_creates_span_with_correct_attributes(
     mock_tracer: mock.MagicMock, client: Client, image_format: ImageFormat
 ):

--- a/tests/telemetry_test.py
+++ b/tests/telemetry_test.py
@@ -7,7 +7,7 @@ from opentelemetry.sdk.resources import SERVICE_NAME, SERVICE_VERSION
 from opentelemetry.sdk.trace import TracerProvider
 
 from xai_sdk.__about__ import __version__ as xai_sdk_version
-from xai_sdk.telemetry import Telemetry, get_tracer
+from xai_sdk.telemetry import Telemetry, get_tracer, should_disable_sensitive_attributes
 
 
 def test_telemetry_creates_provider():
@@ -52,3 +52,20 @@ def test_get_tracer_returns_noop_tracer_when_disabled(disable_value):
     with mock.patch.dict(os.environ, {"XAI_SDK_DISABLE_TRACING": disable_value}):
         tracer = get_tracer("test-tracer")
         assert isinstance(tracer, otel_trace.NoOpTracer)
+
+
+def test_should_disable_sensitive_attributes_returns_false_by_default():
+    # By default, without env var, it should return False
+    assert not should_disable_sensitive_attributes()
+
+
+@pytest.mark.parametrize("disable_value", ["1", "true", "True", "TRUE"])
+def test_should_disable_sensitive_attributes_returns_true_when_disabled(disable_value):
+    with mock.patch.dict(os.environ, {"XAI_SDK_DISABLE_SENSITIVE_TELEMETRY_ATTRIBUTES": disable_value}):
+        assert should_disable_sensitive_attributes()
+
+
+@pytest.mark.parametrize("enable_value", ["0", "false", "False", "FALSE", "anything_else"])
+def test_should_disable_sensitive_attributes_returns_false_when_enabled(enable_value):
+    with mock.patch.dict(os.environ, {"XAI_SDK_DISABLE_SENSITIVE_TELEMETRY_ATTRIBUTES": enable_value}):
+        assert not should_disable_sensitive_attributes()


### PR DESCRIPTION
- Add new env var `XAI_SDK_DISABLE_SENSITIVE_TELEMETRY_ATTRIBUTES`, which when set, omits all sensitive attributes for traces generated by the SDK such as input prompt, model response etc
