### PR TITLE
Rename internal ChoiceChunk class to CompletionOutputChunk

### DIFF
--- a/tests/aio/chat_test.py
+++ b/tests/aio/chat_test.py
@@ -1656,7 +1656,6 @@ def test_chat_append_response(client: AsyncClient):
         outputs=[
             chat_pb2.CompletionOutput(
                 finish_reason=sample_pb2.FinishReason.REASON_STOP,
-                index=0,
                 message=chat_pb2.CompletionMessage(
                     role=chat_pb2.ROLE_ASSISTANT, content="Hello, this is a test response!"
                 ),


### PR DESCRIPTION
- Rename internal `ChoiceChunk` class to `CompletionOutputChunk` following the proto update