### PR TITLE
Add option to use an insecure gRPC channel in clients

### DIFF
--- a/src/xai_sdk/interceptors.py
+++ b/src/xai_sdk/interceptors.py
@@ -1,0 +1,143 @@
+from typing import Optional
+
+import grpc
+
+
+# Sync interceptors
+class AuthInterceptor(grpc.UnaryUnaryClientInterceptor, grpc.UnaryStreamClientInterceptor):
+    """A gRPC interceptor that adds authentication headers for insecure channels."""
+
+    def __init__(self, api_key: str, metadata: Optional[tuple[tuple[str, str], ...]] = None) -> None:
+        """Initialize the AuthInterceptor with API key and optional metadata."""
+        self._api_key = api_key
+        self._metadata = metadata
+
+    def _add_auth_metadata(self, client_call_details):
+        """Adds authentication metadata to the call details."""
+        existing_metadata = list(client_call_details.metadata or [])
+
+        auth_header = ("authorization", f"Bearer {self._api_key}")
+        existing_metadata.append(auth_header)
+
+        if self._metadata:
+            existing_metadata.extend(self._metadata)
+
+        return client_call_details._replace(metadata=existing_metadata)
+
+    def intercept_unary_unary(self, continuation, client_call_details, request):
+        """Intercept unary-unary calls to add authentication metadata."""
+        new_details = self._add_auth_metadata(client_call_details)
+        return continuation(new_details, request)
+
+    def intercept_unary_stream(self, continuation, client_call_details, request):
+        """Intercept unary-stream calls to add authentication metadata."""
+        new_details = self._add_auth_metadata(client_call_details)
+        return continuation(new_details, request)
+
+
+class TimeoutInterceptor(grpc.UnaryUnaryClientInterceptor, grpc.UnaryStreamClientInterceptor):
+    """A gRPC interceptor that sets a default timeout for all requests."""
+
+    def __init__(self, timeout: float) -> None:
+        """Initializes a new instance of the `TimeoutInterceptor` class.
+
+        Args:
+            timeout: The timeout in seconds that will be applied to all requests when this interceptor is used.
+        """
+        self.timeout = timeout
+
+    def _intercept_call(self, continuation, client_call_details, request):
+        client_call_details = client_call_details._replace(timeout=self.timeout)
+        return continuation(client_call_details, request)
+
+    def intercept_unary_unary(self, continuation, client_call_details, request):
+        """Intercepts a unary-unary RPC call."""
+        return self._intercept_call(continuation, client_call_details, request)
+
+    def intercept_unary_stream(self, continuation, client_call_details, request):
+        """Intercepts a unary-stream RPC call."""
+        return self._intercept_call(continuation, client_call_details, request)
+
+
+# Async interceptors
+
+# It's not possible to create a single AsyncInterceptor that can inherit from all the different rpc variants.
+# see: https://github.com/grpc/grpc/issues/31442
+
+
+class UnaryUnaryAuthAioInterceptor(grpc.aio.UnaryUnaryClientInterceptor):
+    """Async interceptor for unary-unary calls that adds the api key to the rpc metadata."""
+
+    def __init__(self, api_key: str, metadata: Optional[tuple[tuple[str, str], ...]] = None) -> None:
+        """Initialize the UnaryUnaryAuthAioInterceptor with API key and optional metadata."""
+        self._api_key = api_key
+        self._metadata = metadata
+
+    def _add_auth_metadata(self, client_call_details):
+        """Adds authentication metadata to the call details."""
+        existing_metadata = list(client_call_details.metadata or [])
+
+        auth_header = ("authorization", f"Bearer {self._api_key}")
+        existing_metadata.append(auth_header)
+
+        if self._metadata:
+            existing_metadata.extend(self._metadata)
+
+        return client_call_details._replace(metadata=existing_metadata)
+
+    async def intercept_unary_unary(self, continuation, client_call_details, request):
+        """Intercept async unary-unary calls to add authentication metadata."""
+        new_details = self._add_auth_metadata(client_call_details)
+        return await continuation(new_details, request)  # type: ignore
+
+
+class UnaryStreamAuthAioInterceptor(grpc.aio.UnaryStreamClientInterceptor):
+    """Async interceptor for unary-stream calls that adds the api key to the rpc metadata."""
+
+    def __init__(self, api_key: str, metadata: Optional[tuple[tuple[str, str], ...]] = None) -> None:
+        """Initialize the UnaryStreamAuthAioInterceptor with API key and optional metadata."""
+        self._api_key = api_key
+        self._metadata = metadata
+
+    def _add_auth_metadata(self, client_call_details):
+        """Adds authentication metadata to the call details."""
+        existing_metadata = list(client_call_details.metadata or [])
+
+        auth_header = ("authorization", f"Bearer {self._api_key}")
+        existing_metadata.append(auth_header)
+
+        if self._metadata:
+            existing_metadata.extend(self._metadata)
+
+        return client_call_details._replace(metadata=existing_metadata)
+
+    async def intercept_unary_stream(self, continuation, client_call_details, request):
+        """Intercept async unary-stream calls to add authentication metadata."""
+        new_details = self._add_auth_metadata(client_call_details)
+        return await continuation(new_details, request)  # type: ignore[reportAwaitable]
+
+
+class UnaryUnaryTimeoutAioInterceptor(grpc.aio.UnaryUnaryClientInterceptor):
+    """Async interceptor for unary-unary calls that sets a default timeout for all requests."""
+
+    def __init__(self, timeout: float) -> None:
+        """Initialize the UnaryUnaryTimeoutAioInterceptor with timeout value."""
+        self.timeout = timeout
+
+    async def intercept_unary_unary(self, continuation, client_call_details, request):
+        """Intercept async unary-unary calls to set timeout."""
+        client_call_details = client_call_details._replace(timeout=self.timeout)  # type: ignore
+        return await continuation(client_call_details, request)
+
+
+class UnaryStreamTimeoutAioInterceptor(grpc.aio.UnaryStreamClientInterceptor):
+    """Async interceptor for unary-stream calls that sets a default timeout for all requests."""
+
+    def __init__(self, timeout: float) -> None:
+        """Initialize the UnaryStreamTimeoutAioInterceptor with timeout value."""
+        self.timeout = timeout
+
+    async def intercept_unary_stream(self, continuation, client_call_details, request):
+        """Intercept async unary-stream calls to set timeout."""
+        client_call_details = client_call_details._replace(timeout=self.timeout)  # type: ignore
+        return await continuation(client_call_details, request)  # type: ignore[reportAwaitable]

--- a/tests/aio/client_test.py
+++ b/tests/aio/client_test.py
@@ -118,3 +118,68 @@ async def test_timeout_unary_stream():
                 pass
 
         assert exc.value.code() == grpc.StatusCode.DEADLINE_EXCEEDED  # type: ignore
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_insecure_client_auth():
+    """Test that insecure client works with auth interceptors."""
+    with server.run_test_server() as port:
+        client = AsyncClient(api_key=server.API_KEY, api_host=f"localhost:{port}", use_insecure_channel=True)
+
+        api_key = await client.auth.get_api_key_info()
+        assert api_key.redacted_api_key == "1**"
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_insecure_client_wrong_api_key():
+    """Test that insecure client fails with wrong API key."""
+    with server.run_test_server() as port:
+        client = AsyncClient(api_key=server.API_KEY + "bad", api_host=f"localhost:{port}", use_insecure_channel=True)
+
+        with pytest.raises(grpc.aio.AioRpcError):
+            await client.auth.get_api_key_info()
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_insecure_client_timeout_unary_unary():
+    """Test that insecure client timeout works for unary-unary calls."""
+    with server.run_test_server(response_delay_seconds=2) as port:
+        client = AsyncClient(api_key=server.API_KEY, api_host=f"localhost:{port}", timeout=1, use_insecure_channel=True)
+
+        with pytest.raises(grpc.aio.AioRpcError) as exc:
+            chat = client.chat.create(model="grok-3")
+            chat.append(user("Hello, world!"))
+            await chat.sample()
+
+        assert exc.value.code() == grpc.StatusCode.DEADLINE_EXCEEDED  # type: ignore
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_insecure_client_timeout_unary_stream():
+    """Test that insecure client timeout works for unary-stream calls."""
+    with server.run_test_server(response_delay_seconds=2) as port:
+        client = AsyncClient(api_key=server.API_KEY, api_host=f"localhost:{port}", timeout=1, use_insecure_channel=True)
+
+        with pytest.raises(grpc.aio.AioRpcError) as exc:
+            chat = client.chat.create(model="grok-3")
+            chat.append(user("Hello, world!"))
+            async for _, _ in chat.stream():
+                pass
+
+        assert exc.value.code() == grpc.StatusCode.DEADLINE_EXCEEDED  # type: ignore
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_insecure_client_with_metadata():
+    """Test that insecure client works with additional metadata."""
+    with server.run_test_server() as port:
+        client = AsyncClient(
+            api_key=server.API_KEY,
+            api_host=f"localhost:{port}",
+            metadata=(("custom-header", "custom-value"), ("another-header", "another-value")),
+            use_insecure_channel=True,
+        )
+
+        # This should work - the metadata is sent but we don't validate it server-side
+        api_key = await client.auth.get_api_key_info()
+        assert api_key.redacted_api_key == "1**"

--- a/tests/sync/client_test.py
+++ b/tests/sync/client_test.py
@@ -110,3 +110,63 @@ def test_timeout_unary_stream():
                 pass
 
         assert excinfo.value.code() == grpc.StatusCode.DEADLINE_EXCEEDED  # type: ignore
+
+
+def test_insecure_client_auth():
+    """Test that insecure client works with auth interceptors."""
+    with server.run_test_server() as port:
+        client = Client(api_key=server.API_KEY, api_host=f"localhost:{port}", use_insecure_channel=True)
+
+        api_key = client.auth.get_api_key_info()
+        assert api_key.redacted_api_key == "1**"
+
+
+def test_insecure_client_wrong_api_key():
+    """Test that insecure client fails with wrong API key."""
+    with server.run_test_server() as port:
+        client = Client(api_key=server.API_KEY + "bad", api_host=f"localhost:{port}", use_insecure_channel=True)
+
+        with pytest.raises(grpc.RpcError):
+            client.auth.get_api_key_info()
+
+
+def test_insecure_client_timeout_unary_unary():
+    """Test that insecure client timeout works for unary-unary calls."""
+    with server.run_test_server(response_delay_seconds=2) as port:
+        client = Client(api_key=server.API_KEY, api_host=f"localhost:{port}", timeout=1, use_insecure_channel=True)
+
+        with pytest.raises(grpc.RpcError) as excinfo:
+            chat = client.chat.create(model="grok-3")
+            chat.append(user("Hello, world!"))
+            chat.sample()
+
+        assert excinfo.value.code() == grpc.StatusCode.DEADLINE_EXCEEDED  # type: ignore
+
+
+def test_insecure_client_timeout_unary_stream():
+    """Test that insecure client timeout works for unary-stream calls."""
+    with server.run_test_server(response_delay_seconds=2) as port:
+        client = Client(api_key=server.API_KEY, api_host=f"localhost:{port}", timeout=1, use_insecure_channel=True)
+
+        with pytest.raises(grpc.RpcError) as excinfo:
+            chat = client.chat.create(model="grok-3")
+            chat.append(user("Hello, world!"))
+            for _, _ in chat.stream():
+                pass
+
+        assert excinfo.value.code() == grpc.StatusCode.DEADLINE_EXCEEDED  # type: ignore
+
+
+def test_insecure_client_with_metadata():
+    """Test that insecure client works with additional metadata."""
+    with server.run_test_server() as port:
+        client = Client(
+            api_key=server.API_KEY,
+            api_host=f"localhost:{port}",
+            metadata=(("custom-header", "custom-value"), ("another-header", "another-value")),
+            use_insecure_channel=True,
+        )
+
+        # This should work - the metadata is sent but we don't validate it server-side
+        api_key = client.auth.get_api_key_info()
+        assert api_key.redacted_api_key == "1**"


### PR DESCRIPTION
- Add new parameter to client constructors, `use_insecure_channel,` allowing use of insecure gRPC channel.
- Add new auth interceptors that add api key to metadata for use with insecure clients
- Create dedicate file to house all gRPC interceptors
- Updated client implementations to utilize new interceptor structure for authentication.
- Added tests for insecure client functionality, including authentication and timeout scenarios.