### PR TITLE
Add util function for retrieving tool-call-type

### DIFF
--- a/src/xai_sdk/tools.py
+++ b/src/xai_sdk/tools.py
@@ -138,3 +138,16 @@ def code_execution() -> chat_pb2.Tool:
         ```
     """
     return chat_pb2.Tool(code_execution=chat_pb2.CodeExecution())
+
+
+def get_tool_call_type(tool_call: chat_pb2.ToolCall) -> str:
+    """Gets the type of a tool call.
+
+    Args:
+        tool_call: The tool call to get the type of.
+
+    Returns:
+        The type of the tool call as a string, valid values are: "client_side_tool", "web_search_tool",
+        "x_search_tool", "code_execution_tool", "collections_search_tool", "mcp_tool".
+    """
+    return chat_pb2.ToolCallType.Name(tool_call.type).removeprefix("TOOL_CALL_TYPE_").lower()

--- a/tests/chat_test.py
+++ b/tests/chat_test.py
@@ -1,5 +1,6 @@
 from xai_sdk.chat import Response
 from xai_sdk.proto import chat_pb2, sample_pb2
+from xai_sdk.tools import get_tool_call_type
 
 
 def test_lazy_buffering_accumulates_chunks():
@@ -257,3 +258,11 @@ def test_lazy_buffering_with_streaming():
 
     # After first sync, buffer should contain consolidated string
     assert response._content_buffers[0] == ["The quick brown fox jumps"]
+
+
+def test_get_tool_call_type():
+    """Test the get_tool_call_type function."""
+    server_side_tool_call = chat_pb2.ToolCall(type=chat_pb2.ToolCallType.TOOL_CALL_TYPE_WEB_SEARCH_TOOL)
+    assert get_tool_call_type(server_side_tool_call) == "web_search_tool"
+    client_side_tool_call = chat_pb2.ToolCall(type=chat_pb2.ToolCallType.TOOL_CALL_TYPE_CLIENT_SIDE_TOOL)
+    assert get_tool_call_type(client_side_tool_call) == "client_side_tool"


### PR DESCRIPTION
# Pull Request Title

## Checklist
- [x] I have read both the [CONTRIBUTING.md](CONTRIBUTING.md) and [Contributor License Agreement](CLA.md) documents.
- [x] I have created an issue or feature request and received approval from xAI maintainers. (minor changes like fixing typos can skip this step)
- [x] I have tested my changes locally and they pass all CI checks.
- [ ] I have added necessary documentation or updated existing documentation. 

## Description
Add the util function to retrieve the tool call type from a tool call returned by the service.

## Related Issue
If applicable, link to the related feature request or bug report issue (e.g., #123). If none, state "N/A".

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please specify)

## Additional Notes
Add any other information or context that might be helpful for reviewers.