### PR TITLE
Set index correctly in `parse` method

### DIFF
--- a/src/xai_sdk/aio/chat.py
+++ b/src/xai_sdk/aio/chat.py
@@ -299,7 +299,8 @@ class Chat(BaseChat):
             attributes=self._make_span_request_attributes(),
         ) as span:
             response = await self._stub.GetCompletion(self._make_request(1))
-            r = Response(response, 0)
+            index = None if self._uses_server_side_tools() else 0
+            r = Response(response, index)
             parsed = shape.model_validate_json(r.content)
             span.set_attributes(self._make_span_response_attributes([r]))
             return r, parsed

--- a/src/xai_sdk/sync/chat.py
+++ b/src/xai_sdk/sync/chat.py
@@ -290,7 +290,8 @@ class Chat(BaseChat):
             attributes=self._make_span_request_attributes(),
         ) as span:
             response = self._stub.GetCompletion(self._make_request(1))
-            r = Response(response, 0)
+            index = None if self._uses_server_side_tools() else 0
+            r = Response(response, index)
             parsed = shape.model_validate_json(r.content)
             span.set_attributes(self._make_span_response_attributes([r]))
             return r, parsed


### PR DESCRIPTION
- Set index correctly in `parse` method to handle requests which produce multiple outputs in the response (e.g. agentic tool calling requests)