### PR TITLE
Allow passing a Pydantic BaseModel to `response_format` directly in `chat.create`

### DIFF
--- a/examples/aio/structured_outputs.py
+++ b/examples/aio/structured_outputs.py
@@ -52,9 +52,56 @@ async def structured_output(client: AsyncClient) -> None:
     print(f"Total: {receipt.total_in_cents / 100} {receipt.currency}")
 
 
+async def alternate_structured_output(client: AsyncClient) -> None:
+    """Extract structured information from an image using a Pydantic model."""
+
+    class Item(BaseModel):
+        name: str
+        quantity: int
+        price_in_cents: int
+
+    class Receipt(BaseModel):
+        date: datetime
+        items: list[Item]
+        currency: str
+        total_in_cents: int
+
+    # Alternatively, you can pass the Pydantic model directly to the
+    # response_format parameter of the chat.create method.
+    chat = client.chat.create(
+        model="grok-4-fast",
+        response_format=Receipt,
+        messages=[
+            system("You are an expert at extracting information from receipts. You pay great attention to detail."),
+        ],
+    )
+
+    chat.append(
+        user(
+            "Extract the information contained in this receipt.",
+            image(
+                "https://images.pexels.com/photos/13431759/pexels-photo-13431759.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2",
+                detail="high",
+            ),
+        )
+    )
+
+    response = await chat.sample()
+    print(response.content, end="\n\n")
+
+    receipt = Receipt.model_validate_json(response.content)
+    assert isinstance(receipt, Receipt)
+
+    for item in receipt.items:
+        print(f"{item.quantity}x {item.name} - {item.price_in_cents / 100} {receipt.currency}")
+
+    print(f"Total: {receipt.total_in_cents / 100} {receipt.currency}")
+
+
 async def main() -> None:
     client = AsyncClient()
     await structured_output(client)
+    # await alternate_structured_output(client)
 
 
 if __name__ == "__main__":

--- a/tests/aio/chat_test.py
+++ b/tests/aio/chat_test.py
@@ -414,7 +414,7 @@ async def test_agentic_tool_calling_non_streaming(client):
 
 
 @pytest.mark.asyncio(loop_scope="session")
-async def test_structured_output(client):
+async def test_structured_output_parse(client):
     class Weather(BaseModel):
         city: str
         units: str
@@ -429,6 +429,26 @@ async def test_structured_output(client):
     assert receipt.city == "London"
     assert receipt.units == "C"
     assert receipt.temperature == 20
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_structured_output_chat_create(client):
+    class Weather(BaseModel):
+        city: str
+        units: str
+        temperature: int
+
+    chat = client.chat.create("grok-3-latest", response_format=Weather)
+    chat.append(user("What is the weather in London?"))
+    response = await chat.sample()
+
+    assert response.content == '{"city":"London","units":"C", "temperature": 20}'
+    # Parse the JSON response into the expected model
+    weather = Weather.model_validate_json(response.content)
+    assert isinstance(weather, Weather)
+    assert weather.city == "London"
+    assert weather.units == "C"
+    assert weather.temperature == 20
 
 
 @pytest.mark.asyncio(loop_scope="session")
@@ -1477,6 +1497,11 @@ def test_chat_create_with_required_tool(client: AsyncClient):
     assert chat_completion_request.tool_choice == chat_pb2.ToolChoice(function_name="get_weather")
 
 
+class Person(BaseModel):
+    name: str
+    age: int
+
+
 @pytest.mark.parametrize(
     "response_format",
     [
@@ -1488,6 +1513,7 @@ def test_chat_create_with_required_tool(client: AsyncClient):
             format_type=chat_pb2.FORMAT_TYPE_JSON_SCHEMA,
             schema='{"type": "object", "properties": {"name": {"type": "string"}, "age": {"type": "number"}}}',
         ),
+        Person,
     ],
 )
 def test_chat_create_with_response_format(
@@ -1505,6 +1531,11 @@ def test_chat_create_with_response_format(
         )
     elif response_format == "text":
         assert chat_completion_request.response_format == chat_pb2.ResponseFormat(format_type=chat_pb2.FORMAT_TYPE_TEXT)
+    elif isinstance(response_format, type) and issubclass(response_format, BaseModel):
+        assert chat_completion_request.response_format == chat_pb2.ResponseFormat(
+            format_type=chat_pb2.FORMAT_TYPE_JSON_SCHEMA,
+            schema=json.dumps(response_format.model_json_schema()),
+        )
     else:
         assert chat_completion_request.response_format == response_format
 


### PR DESCRIPTION
- Updated the `response_format` parameter in the `chat.create` method to accept instances of Pydantic BaseModel model types.
- Update structured output examples to showcase new method
- Add new tests and update existing structured output tests