### PR TITLE
Auto-detect server-side implicit tool additions in chat

### DIFF
--- a/src/xai_sdk/aio/chat.py
+++ b/src/xai_sdk/aio/chat.py
@@ -108,6 +108,7 @@ class Chat(BaseChat):
         ) as span:
             index = None if self._uses_server_side_tools() else 0
             response_pb = await self._stub.GetCompletion(self._make_request(1))
+            index = self._auto_detect_multi_output_mode(index, response_pb.outputs)
             response = Response(response_pb, index)
             span.set_attributes(self._make_span_response_attributes([response]))
             return response
@@ -191,6 +192,10 @@ class Chat(BaseChat):
                         "gen_ai.completion.start_time", datetime.datetime.now(datetime.timezone.utc).isoformat()
                     )
                     first_chunk_received = True
+
+                # Auto-detect if server added tools implicitly
+                index = self._auto_detect_multi_output_mode(index, chunk.outputs)
+                response._index = index
 
                 response.process_chunk(chunk)
                 chunk_obj = Chunk(chunk, index)
@@ -300,6 +305,7 @@ class Chat(BaseChat):
         ) as span:
             response = await self._stub.GetCompletion(self._make_request(1))
             index = None if self._uses_server_side_tools() else 0
+            index = self._auto_detect_multi_output_mode(index, response.outputs)
             r = Response(response, index)
             parsed = shape.model_validate_json(r.content)
             span.set_attributes(self._make_span_response_attributes([r]))


### PR DESCRIPTION
# Auto-detect server-side implicit tool additions in chat

## Checklist
- [x] I have read both the [CONTRIBUTING.md](CONTRIBUTING.md) and [Contributor License Agreement](CLA.md) documents.
- [x] I have created an issue or feature request and received approval from xAI maintainers. (minor changes like fixing typos can skip this step)
- [x] I have tested my changes locally and they pass all CI checks.
- [x] I have added necessary documentation or updated existing documentation. 

## Description
Detect when server switches to multi-output mode by adding tools implicitly. If client expects single-output (`index=0`) but response has multi-output indices, automatically switch to multi-output mode (`index=None`) for proper response handling.

## Related Issue
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other (please specify)