### PR TITLE
Bump version from v1.3.1 -> v1.4.0

### DIFF
--- a/src/xai_sdk/__about__.py
+++ b/src/xai_sdk/__about__.py
@@ -3,4 +3,4 @@
 # To change the version, do so using `uv run hatch version <new-version>`
 # or `uv run hatch version <patch|minor|major>` to bump the patch/minor/major version respectively.
 # See https://hatch.pypa.io/latest/version/#updating for more details.
-__version__ = "1.3.1"
+__version__ = "1.4.0"


### PR DESCRIPTION
- Prepare to release version 1.4.0 of the xAI Python SDK