### PR TITLE
Update Emitted Chat Spans to be compliant with OTEL `gen_ai` spec's changes

### DIFF
--- a/src/xai_sdk/chat.py
+++ b/src/xai_sdk/chat.py
@@ -369,10 +369,11 @@ class BaseChat(ProtoDecorator[chat_pb2.GetCompletionsRequest]):
         """Creates a dictionary with all relevant request attributes to be set on the span as it is created."""
         attributes: dict[str, Any] = {
             "gen_ai.operation.name": "chat",
-            "gen_ai.system": "xai",
+            "gen_ai.provider.name": "xai",
             "gen_ai.output.type": "text",
             "gen_ai.request.model": self._proto.model,
             "server.port": 443,
+            "server.address": "api.x.ai",
         }
 
         if should_disable_sensitive_attributes():

--- a/tests/aio/chat_test.py
+++ b/tests/aio/chat_test.py
@@ -651,7 +651,7 @@ async def test_sample_creates_span_with_correct_attributes(mock_tracer: mock.Mag
 
     expected_request_attributes = {
         "gen_ai.operation.name": "chat",
-        "gen_ai.system": "xai",
+        "gen_ai.provider.name": "xai",
         "gen_ai.output.type": "text",
         "gen_ai.request.model": "grok-3",
         "gen_ai.request.logprobs": False,
@@ -660,6 +660,7 @@ async def test_sample_creates_span_with_correct_attributes(mock_tracer: mock.Mag
         "gen_ai.request.temperature": 1.0,
         "gen_ai.request.parallel_tool_calls": True,
         "server.port": 443,
+        "server.address": "api.x.ai",
         "gen_ai.conversation.id": conversation_id,
         "gen_ai.prompt.0.role": "user",
         "gen_ai.prompt.0.content": "Hello, how are you?",
@@ -709,10 +710,11 @@ async def test_sample_creates_span_without_sensitive_attributes_when_disabled(
 
     expected_request_attributes = {
         "gen_ai.operation.name": "chat",
-        "gen_ai.system": "xai",
+        "gen_ai.provider.name": "xai",
         "gen_ai.output.type": "text",
         "gen_ai.request.model": "grok-3",
         "server.port": 443,
+        "server.address": "api.x.ai",
     }
 
     mock_tracer.start_as_current_span.assert_called_once_with(
@@ -765,7 +767,7 @@ async def test_sample_creates_span_with_correct_optional_attributes(mock_tracer:
 
     expected_request_attributes = {
         "gen_ai.operation.name": "chat",
-        "gen_ai.system": "xai",
+        "gen_ai.provider.name": "xai",
         "gen_ai.output.type": "json_object",
         "gen_ai.request.model": "grok-3",
         "gen_ai.request.logprobs": True,
@@ -774,6 +776,7 @@ async def test_sample_creates_span_with_correct_optional_attributes(mock_tracer:
         "gen_ai.request.temperature": 0.5,
         "gen_ai.request.parallel_tool_calls": False,
         "server.port": 443,
+        "server.address": "api.x.ai",
         "gen_ai.conversation.id": conversation_id,
         "gen_ai.request.max_tokens": 100,
         "gen_ai.request.seed": 123,
@@ -815,7 +818,7 @@ async def test_sample_batch_creates_span_with_correct_attributes(mock_tracer: mo
 
     expected_request_attributes = {
         "gen_ai.operation.name": "chat",
-        "gen_ai.system": "xai",
+        "gen_ai.provider.name": "xai",
         "gen_ai.output.type": "text",
         "gen_ai.request.model": "grok-3",
         "gen_ai.request.logprobs": False,
@@ -824,6 +827,7 @@ async def test_sample_batch_creates_span_with_correct_attributes(mock_tracer: mo
         "gen_ai.request.temperature": 1.0,
         "gen_ai.request.parallel_tool_calls": True,
         "server.port": 443,
+        "server.address": "api.x.ai",
         "gen_ai.conversation.id": conversation_id,
         "gen_ai.prompt.0.role": "user",
         "gen_ai.prompt.0.content": "Hello, how are you?",
@@ -882,7 +886,7 @@ async def test_stream_creates_span_with_correct_attributes(mock_tracer: mock.Mag
 
     expected_request_attributes = {
         "gen_ai.operation.name": "chat",
-        "gen_ai.system": "xai",
+        "gen_ai.provider.name": "xai",
         "gen_ai.output.type": "text",
         "gen_ai.request.model": "grok-3",
         "gen_ai.request.logprobs": False,
@@ -891,6 +895,7 @@ async def test_stream_creates_span_with_correct_attributes(mock_tracer: mock.Mag
         "gen_ai.request.temperature": 1.0,
         "gen_ai.request.parallel_tool_calls": True,
         "server.port": 443,
+        "server.address": "api.x.ai",
         "gen_ai.conversation.id": conversation_id,
         "gen_ai.prompt.0.role": "user",
         "gen_ai.prompt.0.content": "Hello, how are you?",
@@ -947,7 +952,7 @@ async def test_stream_batch_creates_span_with_correct_attributes(mock_tracer: mo
 
     expected_request_attributes = {
         "gen_ai.operation.name": "chat",
-        "gen_ai.system": "xai",
+        "gen_ai.provider.name": "xai",
         "gen_ai.output.type": "text",
         "gen_ai.request.model": "grok-3",
         "gen_ai.request.logprobs": False,
@@ -956,6 +961,7 @@ async def test_stream_batch_creates_span_with_correct_attributes(mock_tracer: mo
         "gen_ai.request.temperature": 1.0,
         "gen_ai.request.parallel_tool_calls": True,
         "server.port": 443,
+        "server.address": "api.x.ai",
         "gen_ai.conversation.id": conversation_id,
         "gen_ai.prompt.0.role": "user",
         "gen_ai.prompt.0.content": "Hello, how are you?",
@@ -1019,7 +1025,7 @@ async def test_parse_creates_span_with_correct_attributes(mock_tracer: mock.Magi
 
     expected_request_attributes = {
         "gen_ai.operation.name": "chat",
-        "gen_ai.system": "xai",
+        "gen_ai.provider.name": "xai",
         "gen_ai.output.type": "json_schema",
         "gen_ai.request.model": "grok-3",
         "gen_ai.request.logprobs": False,
@@ -1028,6 +1034,7 @@ async def test_parse_creates_span_with_correct_attributes(mock_tracer: mock.Magi
         "gen_ai.request.temperature": 1.0,
         "gen_ai.request.parallel_tool_calls": True,
         "server.port": 443,
+        "server.address": "api.x.ai",
         "gen_ai.conversation.id": conversation_id,
         "gen_ai.prompt.0.role": "user",
         "gen_ai.prompt.0.content": "What's the weather in London?",
@@ -1073,7 +1080,7 @@ async def test_defer_creates_span_with_correct_attributes(mock_tracer: mock.Magi
 
     expected_request_attributes = {
         "gen_ai.operation.name": "chat",
-        "gen_ai.system": "xai",
+        "gen_ai.provider.name": "xai",
         "gen_ai.output.type": "text",
         "gen_ai.request.model": "grok-3",
         "gen_ai.request.logprobs": False,
@@ -1082,6 +1089,7 @@ async def test_defer_creates_span_with_correct_attributes(mock_tracer: mock.Magi
         "gen_ai.request.temperature": 1.0,
         "gen_ai.request.parallel_tool_calls": True,
         "server.port": 443,
+        "server.address": "api.x.ai",
         "gen_ai.conversation.id": conversation_id,
         "gen_ai.prompt.0.role": "user",
         "gen_ai.prompt.0.content": "Hello, how are you?",
@@ -1131,7 +1139,7 @@ async def test_defer_batch_creates_span_with_correct_attributes(mock_tracer: moc
 
     expected_request_attributes = {
         "gen_ai.operation.name": "chat",
-        "gen_ai.system": "xai",
+        "gen_ai.provider.name": "xai",
         "gen_ai.output.type": "text",
         "gen_ai.request.model": "grok-3",
         "gen_ai.request.logprobs": False,
@@ -1140,6 +1148,7 @@ async def test_defer_batch_creates_span_with_correct_attributes(mock_tracer: moc
         "gen_ai.request.temperature": 1.0,
         "gen_ai.request.parallel_tool_calls": True,
         "server.port": 443,
+        "server.address": "api.x.ai",
         "gen_ai.conversation.id": conversation_id,
         "gen_ai.prompt.0.role": "user",
         "gen_ai.prompt.0.content": "Hello, how are you?",
@@ -1200,7 +1209,7 @@ async def test_chat_with_function_calling_creates_span_with_correct_attributes(
 
     expected_request_attributes = {
         "gen_ai.operation.name": "chat",
-        "gen_ai.system": "xai",
+        "gen_ai.provider.name": "xai",
         "gen_ai.output.type": "text",
         "gen_ai.request.model": "grok-3",
         "gen_ai.request.logprobs": False,
@@ -1209,6 +1218,7 @@ async def test_chat_with_function_calling_creates_span_with_correct_attributes(
         "gen_ai.request.temperature": 1.0,
         "gen_ai.request.parallel_tool_calls": True,
         "server.port": 443,
+        "server.address": "api.x.ai",
         "gen_ai.conversation.id": conversation_id,
         "gen_ai.prompt.0.role": "user",
         "gen_ai.prompt.0.content": "What's the weather in London?",
@@ -1281,7 +1291,7 @@ async def test_chat_with_function_call_result_creates_span_with_correct_attribut
 
     expected_request_attributes = {
         "gen_ai.operation.name": "chat",
-        "gen_ai.system": "xai",
+        "gen_ai.provider.name": "xai",
         "gen_ai.output.type": "text",
         "gen_ai.request.model": "grok-3",
         "gen_ai.request.logprobs": False,
@@ -1290,6 +1300,7 @@ async def test_chat_with_function_call_result_creates_span_with_correct_attribut
         "gen_ai.request.temperature": 1.0,
         "gen_ai.request.parallel_tool_calls": True,
         "server.port": 443,
+        "server.address": "api.x.ai",
         "gen_ai.conversation.id": conversation_id,
         "gen_ai.prompt.0.role": "user",
         "gen_ai.prompt.0.content": "What's the weather in London?",

--- a/tests/sync/chat_test.py
+++ b/tests/sync/chat_test.py
@@ -624,7 +624,7 @@ def test_sample_creates_span_with_correct_attributes(mock_tracer: mock.MagicMock
 
     expected_request_attributes = {
         "gen_ai.operation.name": "chat",
-        "gen_ai.system": "xai",
+        "gen_ai.provider.name": "xai",
         "gen_ai.output.type": "text",
         "gen_ai.request.model": "grok-3",
         "gen_ai.request.logprobs": False,
@@ -633,6 +633,7 @@ def test_sample_creates_span_with_correct_attributes(mock_tracer: mock.MagicMock
         "gen_ai.request.temperature": 1.0,
         "gen_ai.request.parallel_tool_calls": True,
         "server.port": 443,
+        "server.address": "api.x.ai",
         "gen_ai.conversation.id": conversation_id,
         "gen_ai.prompt.0.role": "user",
         "gen_ai.prompt.0.content": "Hello, how are you?",
@@ -679,10 +680,11 @@ def test_sample_creates_span_without_sensitive_attributes_when_disabled(mock_tra
 
     expected_request_attributes = {
         "gen_ai.operation.name": "chat",
-        "gen_ai.system": "xai",
+        "gen_ai.provider.name": "xai",
         "gen_ai.output.type": "text",
         "gen_ai.request.model": "grok-3",
         "server.port": 443,
+        "server.address": "api.x.ai",
     }
 
     mock_tracer.start_as_current_span.assert_called_once_with(
@@ -735,7 +737,7 @@ def test_sample_creates_span_with_correct_optional_attributes(mock_tracer: mock.
 
     expected_request_attributes = {
         "gen_ai.operation.name": "chat",
-        "gen_ai.system": "xai",
+        "gen_ai.provider.name": "xai",
         "gen_ai.output.type": "json_object",
         "gen_ai.request.model": "grok-3",
         "gen_ai.request.logprobs": True,
@@ -744,6 +746,7 @@ def test_sample_creates_span_with_correct_optional_attributes(mock_tracer: mock.
         "gen_ai.request.temperature": 0.5,
         "gen_ai.request.parallel_tool_calls": False,
         "server.port": 443,
+        "server.address": "api.x.ai",
         "gen_ai.conversation.id": conversation_id,
         "gen_ai.request.max_tokens": 100,
         "gen_ai.request.seed": 123,
@@ -784,7 +787,7 @@ def test_sample_batch_creates_span_with_correct_attributes(mock_tracer: mock.Mag
 
     expected_request_attributes = {
         "gen_ai.operation.name": "chat",
-        "gen_ai.system": "xai",
+        "gen_ai.provider.name": "xai",
         "gen_ai.output.type": "text",
         "gen_ai.request.model": "grok-3",
         "gen_ai.request.logprobs": False,
@@ -793,6 +796,7 @@ def test_sample_batch_creates_span_with_correct_attributes(mock_tracer: mock.Mag
         "gen_ai.request.temperature": 1.0,
         "gen_ai.request.parallel_tool_calls": True,
         "server.port": 443,
+        "server.address": "api.x.ai",
         "gen_ai.conversation.id": conversation_id,
         "gen_ai.prompt.0.role": "user",
         "gen_ai.prompt.0.content": "Hello, how are you?",
@@ -851,7 +855,7 @@ def test_stream_creates_span_with_correct_attributes(mock_tracer: mock.MagicMock
 
     expected_request_attributes = {
         "gen_ai.operation.name": "chat",
-        "gen_ai.system": "xai",
+        "gen_ai.provider.name": "xai",
         "gen_ai.output.type": "text",
         "gen_ai.request.model": "grok-3",
         "gen_ai.request.logprobs": False,
@@ -860,6 +864,7 @@ def test_stream_creates_span_with_correct_attributes(mock_tracer: mock.MagicMock
         "gen_ai.request.temperature": 1.0,
         "gen_ai.request.parallel_tool_calls": True,
         "server.port": 443,
+        "server.address": "api.x.ai",
         "gen_ai.conversation.id": conversation_id,
         "gen_ai.prompt.0.role": "user",
         "gen_ai.prompt.0.content": "Hello, how are you?",
@@ -916,7 +921,7 @@ def test_stream_batch_creates_span_with_correct_attributes(mock_tracer: mock.Mag
 
     expected_request_attributes = {
         "gen_ai.operation.name": "chat",
-        "gen_ai.system": "xai",
+        "gen_ai.provider.name": "xai",
         "gen_ai.output.type": "text",
         "gen_ai.request.model": "grok-3",
         "gen_ai.request.logprobs": False,
@@ -925,6 +930,7 @@ def test_stream_batch_creates_span_with_correct_attributes(mock_tracer: mock.Mag
         "gen_ai.request.temperature": 1.0,
         "gen_ai.request.parallel_tool_calls": True,
         "server.port": 443,
+        "server.address": "api.x.ai",
         "gen_ai.conversation.id": conversation_id,
         "gen_ai.prompt.0.role": "user",
         "gen_ai.prompt.0.content": "Hello, how are you?",
@@ -985,7 +991,7 @@ def test_parse_creates_span_with_correct_attributes(mock_tracer: mock.MagicMock,
 
     expected_request_attributes = {
         "gen_ai.operation.name": "chat",
-        "gen_ai.system": "xai",
+        "gen_ai.provider.name": "xai",
         "gen_ai.output.type": "json_schema",
         "gen_ai.request.model": "grok-3",
         "gen_ai.request.logprobs": False,
@@ -994,6 +1000,7 @@ def test_parse_creates_span_with_correct_attributes(mock_tracer: mock.MagicMock,
         "gen_ai.request.temperature": 1.0,
         "gen_ai.request.parallel_tool_calls": True,
         "server.port": 443,
+        "server.address": "api.x.ai",
         "gen_ai.conversation.id": conversation_id,
         "gen_ai.prompt.0.role": "user",
         "gen_ai.prompt.0.content": "What's the weather in London?",
@@ -1038,7 +1045,7 @@ def test_defer_creates_span_with_correct_attributes(mock_tracer: mock.MagicMock,
 
     expected_request_attributes = {
         "gen_ai.operation.name": "chat",
-        "gen_ai.system": "xai",
+        "gen_ai.provider.name": "xai",
         "gen_ai.output.type": "text",
         "gen_ai.request.model": "grok-3",
         "gen_ai.request.logprobs": False,
@@ -1047,6 +1054,7 @@ def test_defer_creates_span_with_correct_attributes(mock_tracer: mock.MagicMock,
         "gen_ai.request.temperature": 1.0,
         "gen_ai.request.parallel_tool_calls": True,
         "server.port": 443,
+        "server.address": "api.x.ai",
         "gen_ai.conversation.id": conversation_id,
         "gen_ai.prompt.0.role": "user",
         "gen_ai.prompt.0.content": "Hello, how are you?",
@@ -1095,7 +1103,7 @@ def test_defer_batch_creates_span_with_correct_attributes(mock_tracer: mock.Magi
 
     expected_request_attributes = {
         "gen_ai.operation.name": "chat",
-        "gen_ai.system": "xai",
+        "gen_ai.provider.name": "xai",
         "gen_ai.output.type": "text",
         "gen_ai.request.model": "grok-3",
         "gen_ai.request.logprobs": False,
@@ -1104,6 +1112,7 @@ def test_defer_batch_creates_span_with_correct_attributes(mock_tracer: mock.Magi
         "gen_ai.request.temperature": 1.0,
         "gen_ai.request.parallel_tool_calls": True,
         "server.port": 443,
+        "server.address": "api.x.ai",
         "gen_ai.conversation.id": conversation_id,
         "gen_ai.prompt.0.role": "user",
         "gen_ai.prompt.0.content": "Hello, how are you?",
@@ -1161,7 +1170,7 @@ def test_chat_with_function_calling_creates_span_with_correct_attributes(mock_tr
 
     expected_request_attributes = {
         "gen_ai.operation.name": "chat",
-        "gen_ai.system": "xai",
+        "gen_ai.provider.name": "xai",
         "gen_ai.output.type": "text",
         "gen_ai.request.model": "grok-3",
         "gen_ai.request.logprobs": False,
@@ -1170,6 +1179,7 @@ def test_chat_with_function_calling_creates_span_with_correct_attributes(mock_tr
         "gen_ai.request.temperature": 1.0,
         "gen_ai.request.parallel_tool_calls": True,
         "server.port": 443,
+        "server.address": "api.x.ai",
         "gen_ai.conversation.id": conversation_id,
         "gen_ai.prompt.0.role": "user",
         "gen_ai.prompt.0.content": "What's the weather in London?",
@@ -1241,7 +1251,7 @@ def test_chat_with_function_call_result_creates_span_with_correct_attributes(
 
     expected_request_attributes = {
         "gen_ai.operation.name": "chat",
-        "gen_ai.system": "xai",
+        "gen_ai.provider.name": "xai",
         "gen_ai.output.type": "text",
         "gen_ai.request.model": "grok-3",
         "gen_ai.request.logprobs": False,
@@ -1250,6 +1260,7 @@ def test_chat_with_function_call_result_creates_span_with_correct_attributes(
         "gen_ai.request.temperature": 1.0,
         "gen_ai.request.parallel_tool_calls": True,
         "server.port": 443,
+        "server.address": "api.x.ai",
         "gen_ai.conversation.id": conversation_id,
         "gen_ai.prompt.0.role": "user",
         "gen_ai.prompt.0.content": "What's the weather in London?",


### PR DESCRIPTION
# Update Emitted Chat Spans to be compliant with OTEL gen_ai spec's changes 
## Checklist
- [x] I have read both the [CONTRIBUTING.md](CONTRIBUTING.md) and [Contributor License Agreement](CLA.md) documents.
- [x] I have created an issue or feature request and received approval from xAI maintainers. (minor changes like fixing typos can skip this step)
- [x] I have tested my changes locally and they pass all CI checks.
- [x] I have added necessary documentation or updated existing documentation. 


## Type of Change
updating telemetry configuration



## Summary of changes

Please refer to [this](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-spans.md) to read about the reference `gen_ai` spec for OTEL.

Updates: 
- Emit `xai` under the `gen_ai.provider.name` field instead of the `gen_ai.system` field.
- Emit `server.address` to be `api.x.ai`. I'm not sure if it's to hard code it as the prod endpoint (i.e. what if we are testing the sdk locally/staging). I could alternatively plumb the `api_host` field properly from the grpc channel creation for `Client` down to the clients for each of the individual clients for chat, image, etc. but I'd like to get others' thoughts on this.

[Here](https://github.com/open-telemetry/semantic-conventions/blob/5cb84d1c5001fe903000a58ece5b7d44ea569c86/docs/gen-ai/gen-ai-spans.md) is the reference documentation for OTEL `gen_ai` I am using.