### PR TITLE
Bump version from v1.5.0 -> v1.6.0

### DIFF
--- a/src/xai_sdk/__about__.py
+++ b/src/xai_sdk/__about__.py
@@ -3,4 +3,4 @@
 # To change the version, do so using `uv run hatch version <new-version>`
 # or `uv run hatch version <patch|minor|major>` to bump the patch/minor/major version respectively.
 # See https://hatch.pypa.io/latest/version/#updating for more details.
-__version__ = "1.5.0"
+__version__ = "1.6.0"


### PR DESCRIPTION
- Prepare to release v1.6.0 of the xAI Python SDK