### PR TITLE
Reduce default PollTimer poll interval and introduce default video polling settings

### DIFF
--- a/src/xai_sdk/aio/video.py
+++ b/src/xai_sdk/aio/video.py
@@ -8,6 +8,8 @@ from ..poll_timer import PollTimer
 from ..proto import deferred_pb2, video_pb2
 from ..telemetry import get_tracer
 from ..video import (
+    DEFAULT_VIDEO_POLL_INTERVAL,
+    DEFAULT_VIDEO_TIMEOUT,
     BaseClient,
     VideoAspectRatio,
     VideoResolution,
@@ -74,7 +76,7 @@ class Client(BaseClient):
 
         This wraps `GenerateVideo` + repeated `GetDeferredVideo` calls until the request is complete.
         """
-        timer = PollTimer(timeout, interval)
+        timer = PollTimer(timeout or DEFAULT_VIDEO_TIMEOUT, interval or DEFAULT_VIDEO_POLL_INTERVAL)
         request_pb = _make_generate_request(
             prompt,
             model,

--- a/src/xai_sdk/poll_timer.py
+++ b/src/xai_sdk/poll_timer.py
@@ -21,7 +21,7 @@ class PollTimer:
         """
         self._start = time.time()
         self._timeout = timeout or datetime.timedelta(minutes=10)
-        self._interval = interval or datetime.timedelta(milliseconds=100)
+        self._interval = interval or datetime.timedelta(seconds=1)
 
     def sleep_interval_or_raise(self) -> float:
         """Returns the time to sleep until the next poll.

--- a/src/xai_sdk/sync/video.py
+++ b/src/xai_sdk/sync/video.py
@@ -8,6 +8,8 @@ from ..poll_timer import PollTimer
 from ..proto import deferred_pb2, video_pb2
 from ..telemetry import get_tracer
 from ..video import (
+    DEFAULT_VIDEO_POLL_INTERVAL,
+    DEFAULT_VIDEO_TIMEOUT,
     BaseClient,
     VideoAspectRatio,
     VideoResolution,
@@ -74,7 +76,7 @@ class Client(BaseClient):
 
         This wraps `GenerateVideo` + repeated `GetDeferredVideo` calls until the request is complete.
         """
-        timer = PollTimer(timeout, interval)
+        timer = PollTimer(timeout or DEFAULT_VIDEO_TIMEOUT, interval or DEFAULT_VIDEO_POLL_INTERVAL)
         request_pb = _make_generate_request(
             prompt,
             model,

--- a/src/xai_sdk/video.py
+++ b/src/xai_sdk/video.py
@@ -1,3 +1,4 @@
+import datetime
 from typing import Any, Optional, Union
 
 import grpc
@@ -6,6 +7,9 @@ from .meta import ProtoDecorator
 from .proto import image_pb2, usage_pb2, video_pb2, video_pb2_grpc
 from .telemetry import should_disable_sensitive_attributes
 from .types.video import VideoAspectRatio, VideoAspectRatioMap, VideoResolution, VideoResolutionMap
+
+DEFAULT_VIDEO_POLL_INTERVAL = datetime.timedelta(seconds=1)
+DEFAULT_VIDEO_TIMEOUT = datetime.timedelta(minutes=10)
 
 
 class BaseClient:


### PR DESCRIPTION
- Update `PollTimer` to use a default interval of 1 second instead of 100 milliseconds.
- Add `DEFAULT_VIDEO_POLL_INTERVAL` and `DEFAULT_VIDEO_TIMEOUT` constants for consistent timeout and polling interval across video clients.
- Modify synchronous and asynchronous video client implementations to utilize the new default values for PollTimer initialization.