### PR TITLE
Add support for multi-reference image editing with new `image_urls` parameter

### DIFF
--- a/examples/aio/image_multi_reference_editing.py
+++ b/examples/aio/image_multi_reference_editing.py
@@ -1,0 +1,83 @@
+"""Multi-reference image editing example.
+
+Example:
+  uv run examples/aio/image_multi_reference_editing.py \
+    --prompt "Blend these references into a cyberpunk skyline" \
+    --image-url "https://example.com/one.jpg" \
+    --image-url "https://example.com/two.jpg" \
+    --format url
+"""
+
+import asyncio
+from typing import Sequence, cast
+
+from absl import app, flags
+
+import xai_sdk
+from xai_sdk.aio.image import ImageResponse
+from xai_sdk.image import ImageFormat
+
+N = flags.DEFINE_integer("n", 1, "Number of images to generate.")
+FORMAT = flags.DEFINE_enum("format", "base64", ["base64", "url"], "Image format used to return the result.")
+MODEL = flags.DEFINE_string("model", "grok-imagine-image", "Image generation model to use.")
+OUTPUT_DIR = flags.DEFINE_string("output-dir", None, "Directory to save the generated images.")
+PROMPT = flags.DEFINE_string("prompt", None, "Prompt to edit the input images.", required=True)
+IMAGE_URLS = flags.DEFINE_multi_string(
+    "image-url",
+    [],
+    "Input image URL or base64-encoded string. Repeat for multiple images.",
+)
+
+
+async def edit_images(client: xai_sdk.AsyncClient, image_format: ImageFormat) -> Sequence[ImageResponse]:
+    """Multi-reference image editing using image URLs or base64 strings."""
+    image_urls = list(IMAGE_URLS.value)
+    if not image_urls:
+        raise app.UsageError("At least one --image-url is required.")
+
+    if N.value == 1:
+        response = await client.image.sample(
+            PROMPT.value,
+            model=MODEL.value,
+            image_format=image_format,
+            image_urls=image_urls,
+        )
+        return [response]
+
+    return await client.image.sample_batch(
+        PROMPT.value,
+        n=N.value,
+        model=MODEL.value,
+        image_format=image_format,
+        image_urls=image_urls,
+    )
+
+
+async def save_images(responses: Sequence[ImageResponse]) -> None:
+    """Save images to a file."""
+    for i, image in enumerate(responses):
+        with open(f"{OUTPUT_DIR.value}/image_{i}.jpg", "wb") as f:
+            f.write(await image.image)
+
+
+async def main(argv: Sequence[str]) -> None:
+    if len(argv) > 1:
+        raise app.UsageError("Unexpected command line arguments.")
+
+    if FORMAT.value != "url" and not OUTPUT_DIR.value:
+        raise app.UsageError("--output-dir is required when --format is not url.")
+
+    client = xai_sdk.AsyncClient()
+    image_format: ImageFormat = cast(ImageFormat, FORMAT.value)
+    responses = await edit_images(client, image_format)
+
+    if image_format == "url":
+        for i, image in enumerate(responses):
+            print(f"Image {i} URL: {image.url}")
+        return
+
+    await save_images(responses)
+
+
+if __name__ == "__main__":
+    app.run(lambda argv: asyncio.run(main(argv)))

--- a/examples/sync/image_multi_reference_editing.py
+++ b/examples/sync/image_multi_reference_editing.py
@@ -1,0 +1,82 @@
+"""Multi-reference image editing example.
+
+Example:
+  uv run examples/sync/image_multi_reference_editing.py \
+    --prompt "Blend these references into a cyberpunk skyline" \
+    --image-url "https://example.com/one.jpg" \
+    --image-url "https://example.com/two.jpg" \
+    --format url
+"""
+
+from typing import Sequence, cast
+
+from absl import app, flags
+
+import xai_sdk
+from xai_sdk.image import ImageFormat
+from xai_sdk.sync.image import ImageResponse
+
+N = flags.DEFINE_integer("n", 1, "Number of images to generate.")
+FORMAT = flags.DEFINE_enum("format", "base64", ["base64", "url"], "Image format used to return the result.")
+MODEL = flags.DEFINE_string("model", "grok-imagine-image", "Image generation model to use.")
+OUTPUT_DIR = flags.DEFINE_string("output-dir", None, "Directory to save the generated images.")
+PROMPT = flags.DEFINE_string("prompt", None, "Prompt to edit the input images.", required=True)
+IMAGE_URLS = flags.DEFINE_multi_string(
+    "image-url",
+    [],
+    "Input image URL or base64-encoded string. Repeat for multiple images.",
+)
+
+
+def edit_images(client: xai_sdk.Client, image_format: ImageFormat) -> Sequence[ImageResponse]:
+    """Multi-reference image editing using image URLs or base64 strings."""
+    image_urls = list(IMAGE_URLS.value)
+    if not image_urls:
+        raise app.UsageError("At least one --image-url is required.")
+
+    if N.value == 1:
+        response = client.image.sample(
+            PROMPT.value,
+            model=MODEL.value,
+            image_format=image_format,
+            image_urls=image_urls,
+        )
+        return [response]
+
+    return client.image.sample_batch(
+        PROMPT.value,
+        n=N.value,
+        model=MODEL.value,
+        image_format=image_format,
+        image_urls=image_urls,
+    )
+
+
+def save_images(responses: Sequence[ImageResponse]) -> None:
+    """Save images to a file."""
+    for i, image in enumerate(responses):
+        with open(f"{OUTPUT_DIR.value}/image_{i}.jpg", "wb") as f:
+            f.write(image.image)
+
+
+def main(argv: Sequence[str]) -> None:
+    if len(argv) > 1:
+        raise app.UsageError("Unexpected command line arguments.")
+
+    if FORMAT.value != "url" and not OUTPUT_DIR.value:
+        raise app.UsageError("--output-dir is required when --format is not url.")
+
+    client = xai_sdk.Client()
+    image_format: ImageFormat = cast(ImageFormat, FORMAT.value)
+    responses = edit_images(client, image_format)
+
+    if image_format == "url":
+        for i, image in enumerate(responses):
+            print(f"Image {i} URL: {image.url}")
+        return
+
+    save_images(responses)
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/src/xai_sdk/proto/v5/image_pb2.py
+++ b/src/xai_sdk/proto/v5/image_pb2.py
@@ -25,7 +25,7 @@ _sym_db = _symbol_database.Default()
 from . import usage_pb2 as xai_dot_api_dot_v1_dot_usage__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x16xai/api/v1/image.proto\x12\x07xai_api\x1a\x16xai/api/v1/usage.proto\"\xf7\x02\n\x14GenerateImageRequest\x12\x16\n\x06prompt\x18\x01 \x01(\tR\x06prompt\x12.\n\x05image\x18\x05 \x01(\x0b\x32\x18.xai_api.ImageUrlContentR\x05image\x12\x14\n\x05model\x18\x02 \x01(\tR\x05model\x12\x11\n\x01n\x18\x03 \x01(\x05H\x00R\x01n\x88\x01\x01\x12\x12\n\x04user\x18\x04 \x01(\tR\x04user\x12,\n\x06\x66ormat\x18\x0b \x01(\x0e\x32\x14.xai_api.ImageFormatR\x06\x66ormat\x12\x41\n\x0c\x61spect_ratio\x18\x0e \x01(\x0e\x32\x19.xai_api.ImageAspectRatioH\x01R\x0b\x61spectRatio\x88\x01\x01\x12=\n\nresolution\x18\x0f \x01(\x0e\x32\x18.xai_api.ImageResolutionH\x02R\nresolution\x88\x01\x01\x42\x04\n\x02_nB\x0f\n\r_aspect_ratioB\r\n\x0b_resolutionJ\x04\x08\r\x10\x0e\"\x84\x01\n\rImageResponse\x12/\n\x06images\x18\x01 \x03(\x0b\x32\x17.xai_api.GeneratedImageR\x06images\x12\x14\n\x05model\x18\x02 \x01(\tR\x05model\x12,\n\x05usage\x18\x03 \x01(\x0b\x32\x16.xai_api.SamplingUsageR\x05usage\"|\n\x0eGeneratedImage\x12\x18\n\x06\x62\x61se64\x18\x01 \x01(\tH\x00R\x06\x62\x61se64\x12\x12\n\x03url\x18\x03 \x01(\tH\x00R\x03url\x12-\n\x12respect_moderation\x18\x04 \x01(\x08R\x11respectModerationB\x07\n\x05imageJ\x04\x08\x02\x10\x03\"\\\n\x0fImageUrlContent\x12\x1b\n\timage_url\x18\x01 \x01(\tR\x08imageUrl\x12,\n\x06\x64\x65tail\x18\x02 \x01(\x0e\x32\x14.xai_api.ImageDetailR\x06\x64\x65tail*S\n\x0bImageDetail\x12\x12\n\x0e\x44\x45TAIL_INVALID\x10\x00\x12\x0f\n\x0b\x44\x45TAIL_AUTO\x10\x01\x12\x0e\n\nDETAIL_LOW\x10\x02\x12\x0f\n\x0b\x44\x45TAIL_HIGH\x10\x03*P\n\x0bImageFormat\x12\x16\n\x12IMG_FORMAT_INVALID\x10\x00\x12\x15\n\x11IMG_FORMAT_BASE64\x10\x01\x12\x12\n\x0eIMG_FORMAT_URL\x10\x02*j\n\x0cImageQuality\x12\x17\n\x13IMG_QUALITY_INVALID\x10\x00\x12\x13\n\x0fIMG_QUALITY_LOW\x10\x01\x12\x16\n\x12IMG_QUALITY_MEDIUM\x10\x02\x12\x14\n\x10IMG_QUALITY_HIGH\x10\x03*\xa7\x03\n\x10ImageAspectRatio\x12\x1c\n\x18IMG_ASPECT_RATIO_INVALID\x10\x00\x12\x18\n\x14IMG_ASPECT_RATIO_1_1\x10\x01\x12\x18\n\x14IMG_ASPECT_RATIO_3_4\x10\x02\x12\x18\n\x14IMG_ASPECT_RATIO_4_3\x10\x03\x12\x19\n\x15IMG_ASPECT_RATIO_9_16\x10\x04\x12\x19\n\x15IMG_ASPECT_RATIO_16_9\x10\x05\x12\x18\n\x14IMG_ASPECT_RATIO_2_3\x10\x06\x12\x18\n\x14IMG_ASPECT_RATIO_3_2\x10\x07\x12\x19\n\x15IMG_ASPECT_RATIO_AUTO\x10\x08\x12\x1b\n\x17IMG_ASPECT_RATIO_9_19_5\x10\t\x12\x1b\n\x17IMG_ASPECT_RATIO_19_5_9\x10\n\x12\x19\n\x15IMG_ASPECT_RATIO_9_20\x10\x0b\x12\x19\n\x15IMG_ASPECT_RATIO_20_9\x10\x0c\x12\x18\n\x14IMG_ASPECT_RATIO_1_2\x10\r\x12\x18\n\x14IMG_ASPECT_RATIO_2_1\x10\x0e*[\n\x0fImageResolution\x12\x1a\n\x16IMG_RESOLUTION_INVALID\x10\x00\x12\x15\n\x11IMG_RESOLUTION_1K\x10\x01\x12\x15\n\x11IMG_RESOLUTION_2K\x10\x02\x32Q\n\x05Image\x12H\n\rGenerateImage\x12\x1d.xai_api.GenerateImageRequest\x1a\x16.xai_api.ImageResponse\"\x00\x42Q\n\x0b\x63om.xai_apiB\nImageProtoP\x01\xa2\x02\x03XXX\xaa\x02\x06XaiApi\xca\x02\x06XaiApi\xe2\x02\x12XaiApi\\GPBMetadata\xea\x02\x06XaiApib\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x16xai/api/v1/image.proto\x12\x07xai_api\x1a\x16xai/api/v1/usage.proto\"\xa9\x03\n\x14GenerateImageRequest\x12\x16\n\x06prompt\x18\x01 \x01(\tR\x06prompt\x12.\n\x05image\x18\x05 \x01(\x0b\x32\x18.xai_api.ImageUrlContentR\x05image\x12\x14\n\x05model\x18\x02 \x01(\tR\x05model\x12\x11\n\x01n\x18\x03 \x01(\x05H\x00R\x01n\x88\x01\x01\x12\x12\n\x04user\x18\x04 \x01(\tR\x04user\x12,\n\x06\x66ormat\x18\x0b \x01(\x0e\x32\x14.xai_api.ImageFormatR\x06\x66ormat\x12\x41\n\x0c\x61spect_ratio\x18\x0e \x01(\x0e\x32\x19.xai_api.ImageAspectRatioH\x01R\x0b\x61spectRatio\x88\x01\x01\x12=\n\nresolution\x18\x0f \x01(\x0e\x32\x18.xai_api.ImageResolutionH\x02R\nresolution\x88\x01\x01\x12\x30\n\x06images\x18\x11 \x03(\x0b\x32\x18.xai_api.ImageUrlContentR\x06imagesB\x04\n\x02_nB\x0f\n\r_aspect_ratioB\r\n\x0b_resolutionJ\x04\x08\r\x10\x0e\"\x84\x01\n\rImageResponse\x12/\n\x06images\x18\x01 \x03(\x0b\x32\x17.xai_api.GeneratedImageR\x06images\x12\x14\n\x05model\x18\x02 \x01(\tR\x05model\x12,\n\x05usage\x18\x03 \x01(\x0b\x32\x16.xai_api.SamplingUsageR\x05usage\"|\n\x0eGeneratedImage\x12\x18\n\x06\x62\x61se64\x18\x01 \x01(\tH\x00R\x06\x62\x61se64\x12\x12\n\x03url\x18\x03 \x01(\tH\x00R\x03url\x12-\n\x12respect_moderation\x18\x04 \x01(\x08R\x11respectModerationB\x07\n\x05imageJ\x04\x08\x02\x10\x03\"\\\n\x0fImageUrlContent\x12\x1b\n\timage_url\x18\x01 \x01(\tR\x08imageUrl\x12,\n\x06\x64\x65tail\x18\x02 \x01(\x0e\x32\x14.xai_api.ImageDetailR\x06\x64\x65tail*S\n\x0bImageDetail\x12\x12\n\x0e\x44\x45TAIL_INVALID\x10\x00\x12\x0f\n\x0b\x44\x45TAIL_AUTO\x10\x01\x12\x0e\n\nDETAIL_LOW\x10\x02\x12\x0f\n\x0b\x44\x45TAIL_HIGH\x10\x03*P\n\x0bImageFormat\x12\x16\n\x12IMG_FORMAT_INVALID\x10\x00\x12\x15\n\x11IMG_FORMAT_BASE64\x10\x01\x12\x12\n\x0eIMG_FORMAT_URL\x10\x02*j\n\x0cImageQuality\x12\x17\n\x13IMG_QUALITY_INVALID\x10\x00\x12\x13\n\x0fIMG_QUALITY_LOW\x10\x01\x12\x16\n\x12IMG_QUALITY_MEDIUM\x10\x02\x12\x14\n\x10IMG_QUALITY_HIGH\x10\x03*\xa7\x03\n\x10ImageAspectRatio\x12\x1c\n\x18IMG_ASPECT_RATIO_INVALID\x10\x00\x12\x18\n\x14IMG_ASPECT_RATIO_1_1\x10\x01\x12\x18\n\x14IMG_ASPECT_RATIO_3_4\x10\x02\x12\x18\n\x14IMG_ASPECT_RATIO_4_3\x10\x03\x12\x19\n\x15IMG_ASPECT_RATIO_9_16\x10\x04\x12\x19\n\x15IMG_ASPECT_RATIO_16_9\x10\x05\x12\x18\n\x14IMG_ASPECT_RATIO_2_3\x10\x06\x12\x18\n\x14IMG_ASPECT_RATIO_3_2\x10\x07\x12\x19\n\x15IMG_ASPECT_RATIO_AUTO\x10\x08\x12\x1b\n\x17IMG_ASPECT_RATIO_9_19_5\x10\t\x12\x1b\n\x17IMG_ASPECT_RATIO_19_5_9\x10\n\x12\x19\n\x15IMG_ASPECT_RATIO_9_20\x10\x0b\x12\x19\n\x15IMG_ASPECT_RATIO_20_9\x10\x0c\x12\x18\n\x14IMG_ASPECT_RATIO_1_2\x10\r\x12\x18\n\x14IMG_ASPECT_RATIO_2_1\x10\x0e*[\n\x0fImageResolution\x12\x1a\n\x16IMG_RESOLUTION_INVALID\x10\x00\x12\x15\n\x11IMG_RESOLUTION_1K\x10\x01\x12\x15\n\x11IMG_RESOLUTION_2K\x10\x02\x32Q\n\x05Image\x12H\n\rGenerateImage\x12\x1d.xai_api.GenerateImageRequest\x1a\x16.xai_api.ImageResponse\"\x00\x42Q\n\x0b\x63om.xai_apiB\nImageProtoP\x01\xa2\x02\x03XXX\xaa\x02\x06XaiApi\xca\x02\x06XaiApi\xe2\x02\x12XaiApi\\GPBMetadata\xea\x02\x06XaiApib\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -33,24 +33,24 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'xai.api.v1.image_pb2', _glo
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'\n\013com.xai_apiB\nImageProtoP\001\242\002\003XXX\252\002\006XaiApi\312\002\006XaiApi\342\002\022XaiApi\\GPBMetadata\352\002\006XaiApi'
-  _globals['_IMAGEDETAIL']._serialized_start=792
-  _globals['_IMAGEDETAIL']._serialized_end=875
-  _globals['_IMAGEFORMAT']._serialized_start=877
-  _globals['_IMAGEFORMAT']._serialized_end=957
-  _globals['_IMAGEQUALITY']._serialized_start=959
-  _globals['_IMAGEQUALITY']._serialized_end=1065
-  _globals['_IMAGEASPECTRATIO']._serialized_start=1068
-  _globals['_IMAGEASPECTRATIO']._serialized_end=1491
-  _globals['_IMAGERESOLUTION']._serialized_start=1493
-  _globals['_IMAGERESOLUTION']._serialized_end=1584
+  _globals['_IMAGEDETAIL']._serialized_start=842
+  _globals['_IMAGEDETAIL']._serialized_end=925
+  _globals['_IMAGEFORMAT']._serialized_start=927
+  _globals['_IMAGEFORMAT']._serialized_end=1007
+  _globals['_IMAGEQUALITY']._serialized_start=1009
+  _globals['_IMAGEQUALITY']._serialized_end=1115
+  _globals['_IMAGEASPECTRATIO']._serialized_start=1118
+  _globals['_IMAGEASPECTRATIO']._serialized_end=1541
+  _globals['_IMAGERESOLUTION']._serialized_start=1543
+  _globals['_IMAGERESOLUTION']._serialized_end=1634
   _globals['_GENERATEIMAGEREQUEST']._serialized_start=60
-  _globals['_GENERATEIMAGEREQUEST']._serialized_end=435
-  _globals['_IMAGERESPONSE']._serialized_start=438
-  _globals['_IMAGERESPONSE']._serialized_end=570
-  _globals['_GENERATEDIMAGE']._serialized_start=572
-  _globals['_GENERATEDIMAGE']._serialized_end=696
-  _globals['_IMAGEURLCONTENT']._serialized_start=698
-  _globals['_IMAGEURLCONTENT']._serialized_end=790
-  _globals['_IMAGE']._serialized_start=1586
-  _globals['_IMAGE']._serialized_end=1667
+  _globals['_GENERATEIMAGEREQUEST']._serialized_end=485
+  _globals['_IMAGERESPONSE']._serialized_start=488
+  _globals['_IMAGERESPONSE']._serialized_end=620
+  _globals['_GENERATEDIMAGE']._serialized_start=622
+  _globals['_GENERATEDIMAGE']._serialized_end=746
+  _globals['_IMAGEURLCONTENT']._serialized_start=748
+  _globals['_IMAGEURLCONTENT']._serialized_end=840
+  _globals['_IMAGE']._serialized_start=1636
+  _globals['_IMAGE']._serialized_end=1717
 # @@protoc_insertion_point(module_scope)

--- a/src/xai_sdk/proto/v5/image_pb2.pyi
+++ b/src/xai_sdk/proto/v5/image_pb2.pyi
@@ -81,7 +81,7 @@ IMG_RESOLUTION_1K: ImageResolution
 IMG_RESOLUTION_2K: ImageResolution
 
 class GenerateImageRequest(_message.Message):
-    __slots__ = ("prompt", "image", "model", "n", "user", "format", "aspect_ratio", "resolution")
+    __slots__ = ("prompt", "image", "model", "n", "user", "format", "aspect_ratio", "resolution", "images")
     PROMPT_FIELD_NUMBER: _ClassVar[int]
     IMAGE_FIELD_NUMBER: _ClassVar[int]
     MODEL_FIELD_NUMBER: _ClassVar[int]
@@ -90,6 +90,7 @@ class GenerateImageRequest(_message.Message):
     FORMAT_FIELD_NUMBER: _ClassVar[int]
     ASPECT_RATIO_FIELD_NUMBER: _ClassVar[int]
     RESOLUTION_FIELD_NUMBER: _ClassVar[int]
+    IMAGES_FIELD_NUMBER: _ClassVar[int]
     prompt: str
     image: ImageUrlContent
     model: str
@@ -98,7 +99,8 @@ class GenerateImageRequest(_message.Message):
     format: ImageFormat
     aspect_ratio: ImageAspectRatio
     resolution: ImageResolution
-    def __init__(self, prompt: _Optional[str] = ..., image: _Optional[_Union[ImageUrlContent, _Mapping]] = ..., model: _Optional[str] = ..., n: _Optional[int] = ..., user: _Optional[str] = ..., format: _Optional[_Union[ImageFormat, str]] = ..., aspect_ratio: _Optional[_Union[ImageAspectRatio, str]] = ..., resolution: _Optional[_Union[ImageResolution, str]] = ...) -> None: ...
+    images: _containers.RepeatedCompositeFieldContainer[ImageUrlContent]
+    def __init__(self, prompt: _Optional[str] = ..., image: _Optional[_Union[ImageUrlContent, _Mapping]] = ..., model: _Optional[str] = ..., n: _Optional[int] = ..., user: _Optional[str] = ..., format: _Optional[_Union[ImageFormat, str]] = ..., aspect_ratio: _Optional[_Union[ImageAspectRatio, str]] = ..., resolution: _Optional[_Union[ImageResolution, str]] = ..., images: _Optional[_Iterable[_Union[ImageUrlContent, _Mapping]]] = ...) -> None: ...
 
 class ImageResponse(_message.Message):
     __slots__ = ("images", "model", "usage")

--- a/src/xai_sdk/proto/v6/image_pb2.py
+++ b/src/xai_sdk/proto/v6/image_pb2.py
@@ -22,10 +22,10 @@ _runtime_version.ValidateProtobufRuntimeVersion(
 _sym_db = _symbol_database.Default()
 
 
-from . import usage_pb2 as xai_dot_api_dot_v1_dot_usage__pb2 
+from . import usage_pb2 as xai_dot_api_dot_v1_dot_usage__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x16xai/api/v1/image.proto\x12\x07xai_api\x1a\x16xai/api/v1/usage.proto\"\xf7\x02\n\x14GenerateImageRequest\x12\x16\n\x06prompt\x18\x01 \x01(\tR\x06prompt\x12.\n\x05image\x18\x05 \x01(\x0b\x32\x18.xai_api.ImageUrlContentR\x05image\x12\x14\n\x05model\x18\x02 \x01(\tR\x05model\x12\x11\n\x01n\x18\x03 \x01(\x05H\x00R\x01n\x88\x01\x01\x12\x12\n\x04user\x18\x04 \x01(\tR\x04user\x12,\n\x06\x66ormat\x18\x0b \x01(\x0e\x32\x14.xai_api.ImageFormatR\x06\x66ormat\x12\x41\n\x0c\x61spect_ratio\x18\x0e \x01(\x0e\x32\x19.xai_api.ImageAspectRatioH\x01R\x0b\x61spectRatio\x88\x01\x01\x12=\n\nresolution\x18\x0f \x01(\x0e\x32\x18.xai_api.ImageResolutionH\x02R\nresolution\x88\x01\x01\x42\x04\n\x02_nB\x0f\n\r_aspect_ratioB\r\n\x0b_resolutionJ\x04\x08\r\x10\x0e\"\x84\x01\n\rImageResponse\x12/\n\x06images\x18\x01 \x03(\x0b\x32\x17.xai_api.GeneratedImageR\x06images\x12\x14\n\x05model\x18\x02 \x01(\tR\x05model\x12,\n\x05usage\x18\x03 \x01(\x0b\x32\x16.xai_api.SamplingUsageR\x05usage\"|\n\x0eGeneratedImage\x12\x18\n\x06\x62\x61se64\x18\x01 \x01(\tH\x00R\x06\x62\x61se64\x12\x12\n\x03url\x18\x03 \x01(\tH\x00R\x03url\x12-\n\x12respect_moderation\x18\x04 \x01(\x08R\x11respectModerationB\x07\n\x05imageJ\x04\x08\x02\x10\x03\"\\\n\x0fImageUrlContent\x12\x1b\n\timage_url\x18\x01 \x01(\tR\x08imageUrl\x12,\n\x06\x64\x65tail\x18\x02 \x01(\x0e\x32\x14.xai_api.ImageDetailR\x06\x64\x65tail*S\n\x0bImageDetail\x12\x12\n\x0e\x44\x45TAIL_INVALID\x10\x00\x12\x0f\n\x0b\x44\x45TAIL_AUTO\x10\x01\x12\x0e\n\nDETAIL_LOW\x10\x02\x12\x0f\n\x0b\x44\x45TAIL_HIGH\x10\x03*P\n\x0bImageFormat\x12\x16\n\x12IMG_FORMAT_INVALID\x10\x00\x12\x15\n\x11IMG_FORMAT_BASE64\x10\x01\x12\x12\n\x0eIMG_FORMAT_URL\x10\x02*j\n\x0cImageQuality\x12\x17\n\x13IMG_QUALITY_INVALID\x10\x00\x12\x13\n\x0fIMG_QUALITY_LOW\x10\x01\x12\x16\n\x12IMG_QUALITY_MEDIUM\x10\x02\x12\x14\n\x10IMG_QUALITY_HIGH\x10\x03*\xa7\x03\n\x10ImageAspectRatio\x12\x1c\n\x18IMG_ASPECT_RATIO_INVALID\x10\x00\x12\x18\n\x14IMG_ASPECT_RATIO_1_1\x10\x01\x12\x18\n\x14IMG_ASPECT_RATIO_3_4\x10\x02\x12\x18\n\x14IMG_ASPECT_RATIO_4_3\x10\x03\x12\x19\n\x15IMG_ASPECT_RATIO_9_16\x10\x04\x12\x19\n\x15IMG_ASPECT_RATIO_16_9\x10\x05\x12\x18\n\x14IMG_ASPECT_RATIO_2_3\x10\x06\x12\x18\n\x14IMG_ASPECT_RATIO_3_2\x10\x07\x12\x19\n\x15IMG_ASPECT_RATIO_AUTO\x10\x08\x12\x1b\n\x17IMG_ASPECT_RATIO_9_19_5\x10\t\x12\x1b\n\x17IMG_ASPECT_RATIO_19_5_9\x10\n\x12\x19\n\x15IMG_ASPECT_RATIO_9_20\x10\x0b\x12\x19\n\x15IMG_ASPECT_RATIO_20_9\x10\x0c\x12\x18\n\x14IMG_ASPECT_RATIO_1_2\x10\r\x12\x18\n\x14IMG_ASPECT_RATIO_2_1\x10\x0e*[\n\x0fImageResolution\x12\x1a\n\x16IMG_RESOLUTION_INVALID\x10\x00\x12\x15\n\x11IMG_RESOLUTION_1K\x10\x01\x12\x15\n\x11IMG_RESOLUTION_2K\x10\x02\x32Q\n\x05Image\x12H\n\rGenerateImage\x12\x1d.xai_api.GenerateImageRequest\x1a\x16.xai_api.ImageResponse\"\x00\x42Q\n\x0b\x63om.xai_apiB\nImageProtoP\x01\xa2\x02\x03XXX\xaa\x02\x06XaiApi\xca\x02\x06XaiApi\xe2\x02\x12XaiApi\\GPBMetadata\xea\x02\x06XaiApib\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x16xai/api/v1/image.proto\x12\x07xai_api\x1a\x16xai/api/v1/usage.proto\"\xa9\x03\n\x14GenerateImageRequest\x12\x16\n\x06prompt\x18\x01 \x01(\tR\x06prompt\x12.\n\x05image\x18\x05 \x01(\x0b\x32\x18.xai_api.ImageUrlContentR\x05image\x12\x14\n\x05model\x18\x02 \x01(\tR\x05model\x12\x11\n\x01n\x18\x03 \x01(\x05H\x00R\x01n\x88\x01\x01\x12\x12\n\x04user\x18\x04 \x01(\tR\x04user\x12,\n\x06\x66ormat\x18\x0b \x01(\x0e\x32\x14.xai_api.ImageFormatR\x06\x66ormat\x12\x41\n\x0c\x61spect_ratio\x18\x0e \x01(\x0e\x32\x19.xai_api.ImageAspectRatioH\x01R\x0b\x61spectRatio\x88\x01\x01\x12=\n\nresolution\x18\x0f \x01(\x0e\x32\x18.xai_api.ImageResolutionH\x02R\nresolution\x88\x01\x01\x12\x30\n\x06images\x18\x11 \x03(\x0b\x32\x18.xai_api.ImageUrlContentR\x06imagesB\x04\n\x02_nB\x0f\n\r_aspect_ratioB\r\n\x0b_resolutionJ\x04\x08\r\x10\x0e\"\x84\x01\n\rImageResponse\x12/\n\x06images\x18\x01 \x03(\x0b\x32\x17.xai_api.GeneratedImageR\x06images\x12\x14\n\x05model\x18\x02 \x01(\tR\x05model\x12,\n\x05usage\x18\x03 \x01(\x0b\x32\x16.xai_api.SamplingUsageR\x05usage\"|\n\x0eGeneratedImage\x12\x18\n\x06\x62\x61se64\x18\x01 \x01(\tH\x00R\x06\x62\x61se64\x12\x12\n\x03url\x18\x03 \x01(\tH\x00R\x03url\x12-\n\x12respect_moderation\x18\x04 \x01(\x08R\x11respectModerationB\x07\n\x05imageJ\x04\x08\x02\x10\x03\"\\\n\x0fImageUrlContent\x12\x1b\n\timage_url\x18\x01 \x01(\tR\x08imageUrl\x12,\n\x06\x64\x65tail\x18\x02 \x01(\x0e\x32\x14.xai_api.ImageDetailR\x06\x64\x65tail*S\n\x0bImageDetail\x12\x12\n\x0e\x44\x45TAIL_INVALID\x10\x00\x12\x0f\n\x0b\x44\x45TAIL_AUTO\x10\x01\x12\x0e\n\nDETAIL_LOW\x10\x02\x12\x0f\n\x0b\x44\x45TAIL_HIGH\x10\x03*P\n\x0bImageFormat\x12\x16\n\x12IMG_FORMAT_INVALID\x10\x00\x12\x15\n\x11IMG_FORMAT_BASE64\x10\x01\x12\x12\n\x0eIMG_FORMAT_URL\x10\x02*j\n\x0cImageQuality\x12\x17\n\x13IMG_QUALITY_INVALID\x10\x00\x12\x13\n\x0fIMG_QUALITY_LOW\x10\x01\x12\x16\n\x12IMG_QUALITY_MEDIUM\x10\x02\x12\x14\n\x10IMG_QUALITY_HIGH\x10\x03*\xa7\x03\n\x10ImageAspectRatio\x12\x1c\n\x18IMG_ASPECT_RATIO_INVALID\x10\x00\x12\x18\n\x14IMG_ASPECT_RATIO_1_1\x10\x01\x12\x18\n\x14IMG_ASPECT_RATIO_3_4\x10\x02\x12\x18\n\x14IMG_ASPECT_RATIO_4_3\x10\x03\x12\x19\n\x15IMG_ASPECT_RATIO_9_16\x10\x04\x12\x19\n\x15IMG_ASPECT_RATIO_16_9\x10\x05\x12\x18\n\x14IMG_ASPECT_RATIO_2_3\x10\x06\x12\x18\n\x14IMG_ASPECT_RATIO_3_2\x10\x07\x12\x19\n\x15IMG_ASPECT_RATIO_AUTO\x10\x08\x12\x1b\n\x17IMG_ASPECT_RATIO_9_19_5\x10\t\x12\x1b\n\x17IMG_ASPECT_RATIO_19_5_9\x10\n\x12\x19\n\x15IMG_ASPECT_RATIO_9_20\x10\x0b\x12\x19\n\x15IMG_ASPECT_RATIO_20_9\x10\x0c\x12\x18\n\x14IMG_ASPECT_RATIO_1_2\x10\r\x12\x18\n\x14IMG_ASPECT_RATIO_2_1\x10\x0e*[\n\x0fImageResolution\x12\x1a\n\x16IMG_RESOLUTION_INVALID\x10\x00\x12\x15\n\x11IMG_RESOLUTION_1K\x10\x01\x12\x15\n\x11IMG_RESOLUTION_2K\x10\x02\x32Q\n\x05Image\x12H\n\rGenerateImage\x12\x1d.xai_api.GenerateImageRequest\x1a\x16.xai_api.ImageResponse\"\x00\x42Q\n\x0b\x63om.xai_apiB\nImageProtoP\x01\xa2\x02\x03XXX\xaa\x02\x06XaiApi\xca\x02\x06XaiApi\xe2\x02\x12XaiApi\\GPBMetadata\xea\x02\x06XaiApib\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -33,24 +33,24 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'xai.api.v1.image_pb2', _glo
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'\n\013com.xai_apiB\nImageProtoP\001\242\002\003XXX\252\002\006XaiApi\312\002\006XaiApi\342\002\022XaiApi\\GPBMetadata\352\002\006XaiApi'
-  _globals['_IMAGEDETAIL']._serialized_start=792
-  _globals['_IMAGEDETAIL']._serialized_end=875
-  _globals['_IMAGEFORMAT']._serialized_start=877
-  _globals['_IMAGEFORMAT']._serialized_end=957
-  _globals['_IMAGEQUALITY']._serialized_start=959
-  _globals['_IMAGEQUALITY']._serialized_end=1065
-  _globals['_IMAGEASPECTRATIO']._serialized_start=1068
-  _globals['_IMAGEASPECTRATIO']._serialized_end=1491
-  _globals['_IMAGERESOLUTION']._serialized_start=1493
-  _globals['_IMAGERESOLUTION']._serialized_end=1584
+  _globals['_IMAGEDETAIL']._serialized_start=842
+  _globals['_IMAGEDETAIL']._serialized_end=925
+  _globals['_IMAGEFORMAT']._serialized_start=927
+  _globals['_IMAGEFORMAT']._serialized_end=1007
+  _globals['_IMAGEQUALITY']._serialized_start=1009
+  _globals['_IMAGEQUALITY']._serialized_end=1115
+  _globals['_IMAGEASPECTRATIO']._serialized_start=1118
+  _globals['_IMAGEASPECTRATIO']._serialized_end=1541
+  _globals['_IMAGERESOLUTION']._serialized_start=1543
+  _globals['_IMAGERESOLUTION']._serialized_end=1634
   _globals['_GENERATEIMAGEREQUEST']._serialized_start=60
-  _globals['_GENERATEIMAGEREQUEST']._serialized_end=435
-  _globals['_IMAGERESPONSE']._serialized_start=438
-  _globals['_IMAGERESPONSE']._serialized_end=570
-  _globals['_GENERATEDIMAGE']._serialized_start=572
-  _globals['_GENERATEDIMAGE']._serialized_end=696
-  _globals['_IMAGEURLCONTENT']._serialized_start=698
-  _globals['_IMAGEURLCONTENT']._serialized_end=790
-  _globals['_IMAGE']._serialized_start=1586
-  _globals['_IMAGE']._serialized_end=1667
+  _globals['_GENERATEIMAGEREQUEST']._serialized_end=485
+  _globals['_IMAGERESPONSE']._serialized_start=488
+  _globals['_IMAGERESPONSE']._serialized_end=620
+  _globals['_GENERATEDIMAGE']._serialized_start=622
+  _globals['_GENERATEDIMAGE']._serialized_end=746
+  _globals['_IMAGEURLCONTENT']._serialized_start=748
+  _globals['_IMAGEURLCONTENT']._serialized_end=840
+  _globals['_IMAGE']._serialized_start=1636
+  _globals['_IMAGE']._serialized_end=1717
 # @@protoc_insertion_point(module_scope)

--- a/src/xai_sdk/proto/v6/image_pb2.pyi
+++ b/src/xai_sdk/proto/v6/image_pb2.pyi
@@ -82,7 +82,7 @@ IMG_RESOLUTION_1K: ImageResolution
 IMG_RESOLUTION_2K: ImageResolution
 
 class GenerateImageRequest(_message.Message):
-    __slots__ = ("prompt", "image", "model", "n", "user", "format", "aspect_ratio", "resolution")
+    __slots__ = ("prompt", "image", "model", "n", "user", "format", "aspect_ratio", "resolution", "images")
     PROMPT_FIELD_NUMBER: _ClassVar[int]
     IMAGE_FIELD_NUMBER: _ClassVar[int]
     MODEL_FIELD_NUMBER: _ClassVar[int]
@@ -91,6 +91,7 @@ class GenerateImageRequest(_message.Message):
     FORMAT_FIELD_NUMBER: _ClassVar[int]
     ASPECT_RATIO_FIELD_NUMBER: _ClassVar[int]
     RESOLUTION_FIELD_NUMBER: _ClassVar[int]
+    IMAGES_FIELD_NUMBER: _ClassVar[int]
     prompt: str
     image: ImageUrlContent
     model: str
@@ -99,7 +100,8 @@ class GenerateImageRequest(_message.Message):
     format: ImageFormat
     aspect_ratio: ImageAspectRatio
     resolution: ImageResolution
-    def __init__(self, prompt: _Optional[str] = ..., image: _Optional[_Union[ImageUrlContent, _Mapping]] = ..., model: _Optional[str] = ..., n: _Optional[int] = ..., user: _Optional[str] = ..., format: _Optional[_Union[ImageFormat, str]] = ..., aspect_ratio: _Optional[_Union[ImageAspectRatio, str]] = ..., resolution: _Optional[_Union[ImageResolution, str]] = ...) -> None: ...
+    images: _containers.RepeatedCompositeFieldContainer[ImageUrlContent]
+    def __init__(self, prompt: _Optional[str] = ..., image: _Optional[_Union[ImageUrlContent, _Mapping]] = ..., model: _Optional[str] = ..., n: _Optional[int] = ..., user: _Optional[str] = ..., format: _Optional[_Union[ImageFormat, str]] = ..., aspect_ratio: _Optional[_Union[ImageAspectRatio, str]] = ..., resolution: _Optional[_Union[ImageResolution, str]] = ..., images: _Optional[_Iterable[_Union[ImageUrlContent, _Mapping]]] = ...) -> None: ...
 
 class ImageResponse(_message.Message):
     __slots__ = ("images", "model", "usage")

--- a/src/xai_sdk/sync/image.py
+++ b/src/xai_sdk/sync/image.py
@@ -31,6 +31,7 @@ class Client(BaseClient):
         model: str,
         *,
         image_url: Optional[str] = None,
+        image_urls: Optional[Sequence[str]] = None,
         user: Optional[str] = None,
         image_format: Optional[ImageFormat] = None,
         aspect_ratio: Optional[ImageAspectRatio] = None,
@@ -42,6 +43,11 @@ class Client(BaseClient):
             prompt: The prompt to generate an image from.
             model: The model to use for image generation.
             image_url: The URL or base64-encoded string of an input image to use as a starting point for generation.
+            This field cannot be set together with `image_urls`.
+            Only supported for grok-imagine models.
+            image_urls: Optional list of input images for multi-reference image editing.
+            Each image is a URL or base64-encoded string, matching the `image_url` format.
+            This field cannot be set together with `image_url`.
             Only supported for grok-imagine models.
             user: A unique identifier representing your end-user, which can help xAI to monitor and detect abuse.
             image_format: The format of the image to return. One of:
@@ -71,6 +77,9 @@ class Client(BaseClient):
         Returns:
             An `ImageResponse` object allowing access to the generated image.
         """
+        if image_url is not None and image_urls is not None:
+            raise ValueError("Only one of image_url or image_urls can be set for a request.")
+
         image_format = image_format or "url"
         request = image_pb2.GenerateImageRequest(
             prompt=prompt,
@@ -85,6 +94,16 @@ class Client(BaseClient):
                     image_url=image_url,
                     detail=image_pb2.ImageDetail.DETAIL_AUTO,
                 )
+            )
+        if image_urls is not None:
+            request.images.extend(
+                [
+                    image_pb2.ImageUrlContent(
+                        image_url=url,
+                        detail=image_pb2.ImageDetail.DETAIL_AUTO,
+                    )
+                    for url in image_urls
+                ]
             )
         if aspect_ratio is not None:
             request.aspect_ratio = convert_image_aspect_ratio_to_pb(aspect_ratio)
@@ -108,6 +127,7 @@ class Client(BaseClient):
         n: int,
         *,
         image_url: Optional[str] = None,
+        image_urls: Optional[Sequence[str]] = None,
         user: Optional[str] = None,
         image_format: Optional[ImageFormat] = None,
         aspect_ratio: Optional[ImageAspectRatio] = None,
@@ -120,6 +140,11 @@ class Client(BaseClient):
             model: The model to use for image generation.
             n: The number of images to generate.
             image_url: The URL or base64-encoded string of an input image to use as a starting point for generation.
+            This field cannot be set together with `image_urls`.
+            Only supported for grok-imagine models.
+            image_urls: Optional list of input images for multi-reference image editing.
+            Each image is a URL or base64-encoded string, matching the `image_url` format.
+            This field cannot be set together with `image_url`.
             Only supported for grok-imagine models.
             user: A unique identifier representing your end-user, which can help xAI to monitor and detect abuse.
             image_format: The format of the image to return. One of:
@@ -149,6 +174,9 @@ class Client(BaseClient):
         Returns:
             A sequence of `ImageResponse` objects, one for each image generated.
         """
+        if image_url is not None and image_urls is not None:
+            raise ValueError("Only one of image_url or image_urls can be set for a request.")
+
         image_format = image_format or "url"
         request = image_pb2.GenerateImageRequest(
             prompt=prompt,
@@ -163,6 +191,16 @@ class Client(BaseClient):
                     image_url=image_url,
                     detail=image_pb2.ImageDetail.DETAIL_AUTO,
                 )
+            )
+        if image_urls is not None:
+            request.images.extend(
+                [
+                    image_pb2.ImageUrlContent(
+                        image_url=url,
+                        detail=image_pb2.ImageDetail.DETAIL_AUTO,
+                    )
+                    for url in image_urls
+                ]
             )
         if aspect_ratio is not None:
             request.aspect_ratio = convert_image_aspect_ratio_to_pb(aspect_ratio)


### PR DESCRIPTION
- Add new examples for multi-reference image editing
- Enforce mutual exclusivity of image_url and image_urls parameters in image generation methods
- Add tests to ensure new `image_urls` parameter is passed correctly
