### PR TITLE
docs: update default API requests timeout from 15min(900s) to 27min(1620s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ For privacy reasons, you may want to disable the collection of sensitive attribu
 
 ## Timeouts
 
-The xAI SDK allows you to set a timeout for API requests during client initialization. This timeout applies to all RPCs and methods used with that client instance. The default timeout is 15 minutes (900 seconds).
+The xAI SDK allows you to set a timeout for API requests during client initialization. This timeout applies to all RPCs and methods used with that client instance. The default timeout is 27 minutes (1620 seconds).
 
 It is not currently possible to specify timeouts for an individual RPC/client method.
 
@@ -445,7 +445,7 @@ Below is a table of common gRPC status codes you might encounter when using the 
 |---------------------------|------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
 | `UNKNOWN`                 | An unknown error occurred.                                             | An unexpected issue occurred on the server side, not specifically related to the request.               |
 | `INVALID_ARGUMENT`        | The client specified an invalid argument.                              | An invalid argument was provided to the model/endpoint, such as incorrect parameters or malformed input.|
-| `DEADLINE_EXCEEDED`       | The deadline for the request expired before the operation completed.   | Raised if the request exceeds the timeout specified by the client (default is 900 seconds, configurable during client instantiation). |
+| `DEADLINE_EXCEEDED`       | The deadline for the request expired before the operation completed.   | Raised if the request exceeds the timeout specified by the client (default is 1620 seconds, configurable during client instantiation). |
 | `NOT_FOUND`               | A specified resource was not found.                                    | A requested model or resource does not exist.                                                           |
 | `PERMISSION_DENIED`       | The caller does not have permission to execute the specified operation.| The API key is disabled, blocked, or lacks sufficient permissions to access a specific model or feature. |
 | `UNAUTHENTICATED`         | The request does not have valid authentication credentials.            | The API key is missing, invalid, or expired.                                                            |
@@ -476,12 +476,12 @@ You can easily check the version of the xAI SDK installed in your environment us
   ```bash
   pip show xai-sdk
   ```
-  or 
+  or
 
   ```bash
   uv pip show xai-sdk
   ```
-  
+
   This will display detailed information about the package, including the version number.
 
 - **Programmatically in Python**: You can access the version information directly in your code by importing the SDK and checking the `__version__` attribute:

--- a/src/xai_sdk/client.py
+++ b/src/xai_sdk/client.py
@@ -79,7 +79,7 @@ class BaseClient(abc.ABC):
             channel_options: Additional channel options to be sent with each gRPC request, the options defined here
                 will override the default options if they have the same name.
             timeout: The timeout in seconds for all gRPC requests using this client. If not set, the default
-                timeout of 15 minutes (900 seconds) will be used.
+                timeout of 27 minutes (1620 seconds) will be used.
             use_insecure_channel: Whether to use an insecure gRPC channel. If True, an insecure gRPC client
                 is used for the underlying connection, though the API key will still be applied
                 to outgoing requests via metadata through gRPC interceptors. Defaults to False.


### PR DESCRIPTION
Update default API requests timeout from 15min(900s) to 27min(1620s)

## Checklist
- [x] I have read both the [CONTRIBUTING.md](CONTRIBUTING.md) and [Contributor License Agreement](CLA.md) documents.
- [ ] I have created an issue or feature request and received approval from xAI maintainers. (minor changes like fixing typos can skip this step)
- [ ] I have tested my changes locally and they pass all CI checks.
- [x] I have added necessary documentation or updated existing documentation. 

## Description
Updates all documentation to match the actual code default:

- `_DEFAULT_RPC_TIMEOUT_SECONDS = 27 * 60` (1620 seconds) in `client.py`
- Was previously documented as 15 minutes (900 seconds)

Changed:
- `src/xai_sdk/client.py` (BaseClient docstring)
- `README.md` (Timeouts section + Error Codes table)

## Related Issue
N/A

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Other (please specify)

## Additional Notes
N/A