### PR TITLE
Add `expires_after` to file uploads, drop `team_id` from `File`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Added
+- **Files API**: `client.files.upload()` (sync and async) now accepts an optional `expires_after` parameter to set a TTL on uploaded files. Accepts either an `int` (seconds) or a `datetime.timedelta`. After the duration elapses, the file is automatically deleted.
 - **Collections API Enhancements**:
     - Added `description` parameter to `collections.create()` and `collections.update()` for human-friendly collection descriptions
     - Added `collections.generate_description()` method that asks the API to summarize a collection based on its document contents
@@ -15,6 +16,9 @@
 
 ### Changed
 - **Breaking Change**: `chunk_configuration` validation is now stricter. When `chunk_configuration` is provided, it must specify exactly one of `chars_configuration`, `tokens_configuration`, or `bytes_configuration`. Previously, calls that omitted all three (e.g., to update only `strip_whitespace`) silently succeeded; they now raise `ValueError`. Callers updating only top-level chunk flags must now also include their existing chunking strategy.
+
+### Removed
+- **Breaking Change**: Removed the `team_id` field from `File` responses returned by the Files API (`upload`, `list`, `get`). The same value is available via `client.auth.get_api_key_info().team_id`, which is the canonical source.
 
 ## [v1.6.0](https://github.com/xai-org/xai-sdk-python/releases/tag/v1.6.0) - 2026-01-27
 ### Added

--- a/examples/aio/files.py
+++ b/examples/aio/files.py
@@ -26,7 +26,6 @@ async def upload_example(client: xai_sdk.AsyncClient):
         print(f"Uploaded file: {file.filename}")
         print(f"File ID: {file.id}")
         print(f"File size: {file.size} bytes")
-        print(f"Team ID: {file.team_id}")
         print(f"Created at: {file.created_at.ToDatetime()}")
         return file.id
     finally:
@@ -100,7 +99,6 @@ async def upload_large_file_example(client: xai_sdk.AsyncClient):
         print(f"Successfully uploaded file: {file.filename}")
         print(f"File ID: {file.id}")
         print(f"File size: {file.size} bytes ({file.size / (1024 * 1024):.2f} MB)")
-        print(f"Team ID: {file.team_id}")
         print(f"Created at: {file.created_at.ToDatetime()}")
         return file.id
     finally:

--- a/examples/sync/files.py
+++ b/examples/sync/files.py
@@ -25,7 +25,6 @@ def upload_example(client: xai_sdk.Client):
         print(f"Uploaded file: {file.filename}")
         print(f"File ID: {file.id}")
         print(f"File size: {file.size} bytes")
-        print(f"Team ID: {file.team_id}")
         print(f"Created at: {file.created_at.ToDatetime()}")
         return file.id
     finally:
@@ -99,7 +98,6 @@ def upload_large_file_example(client: xai_sdk.Client):
         print(f"Successfully uploaded file: {file.filename}")
         print(f"File ID: {file.id}")
         print(f"File size: {file.size} bytes ({file.size / (1024 * 1024):.2f} MB)")
-        print(f"Team ID: {file.team_id}")
         print(f"Created at: {file.created_at.ToDatetime()}")
         return file.id
     finally:

--- a/src/xai_sdk/aio/files.py
+++ b/src/xai_sdk/aio/files.py
@@ -1,4 +1,5 @@
 import asyncio
+import datetime
 import os
 from asyncio import Semaphore
 from typing import BinaryIO, Optional, Sequence, Union
@@ -33,6 +34,7 @@ class Client(BaseClient):
         *,
         filename: Optional[str] = None,
         on_progress: Optional[ProgressCallback] = None,
+        expires_after: Optional[Union[datetime.timedelta, int]] = None,
     ) -> files_pb2.File:
         """Upload a file to xAI's servers asynchronously.
 
@@ -55,6 +57,12 @@ class Client(BaseClient):
                   Called with the size of the chunk just uploaded (e.g., tqdm.update).
                 - An object with an `update(n: int)` method (e.g., tqdm progress bar).
                   The update method is called with the chunk size after each upload.
+            expires_after: Optional time-to-live for the file, measured from the moment of upload (creation).
+                After this duration the file is automatically deleted.
+                Can be:
+                - datetime.timedelta: Duration after upload (e.g., timedelta(hours=24)).
+                - int: Number of seconds after upload.
+                If not provided, the file does not expire.
 
         Returns:
             A File proto containing metadata about the uploaded file.
@@ -93,13 +101,22 @@ class Client(BaseClient):
         if isinstance(file, str):
             if not os.path.exists(file):
                 raise FileNotFoundError(f"File not found: {file}")
-            chunks = _async_chunk_file_from_path(file_path=file, progress=on_progress)
+            chunks = _async_chunk_file_from_path(
+                file_path=file,
+                progress=on_progress,
+                expires_after=expires_after,
+            )
 
         # Handle bytes
         elif isinstance(file, bytes | bytearray):
             if not filename:
                 raise ValueError("filename is required when uploading bytes")
-            chunks = _async_chunk_file_data(filename=filename, data=bytes(file), progress=on_progress)
+            chunks = _async_chunk_file_data(
+                filename=filename,
+                data=bytes(file),
+                progress=on_progress,
+                expires_after=expires_after,
+            )
 
         # Handle file-like object (BinaryIO)
         elif hasattr(file, "read"):
@@ -109,7 +126,12 @@ class Client(BaseClient):
                     filename = os.path.basename(file.name)
                 else:
                     raise ValueError("filename is required when uploading a file-like object without a .name attribute")
-            chunks = _async_chunk_file_from_fileobj(file_obj=file, filename=filename, progress=on_progress)
+            chunks = _async_chunk_file_from_fileobj(
+                file_obj=file,
+                filename=filename,
+                progress=on_progress,
+                expires_after=expires_after,
+            )
         else:
             raise ValueError(f"Unsupported file type: {type(file)}")
         with tracer.start_as_current_span(

--- a/src/xai_sdk/files.py
+++ b/src/xai_sdk/files.py
@@ -1,6 +1,7 @@
 import asyncio
+import datetime
 import os
-from typing import Any, AsyncIterator, BinaryIO, Callable, Iterator, Literal, Protocol, Union
+from typing import Any, AsyncIterator, BinaryIO, Callable, Iterator, Literal, Optional, Protocol, Union
 
 import grpc
 
@@ -11,6 +12,15 @@ _CHUNK_SIZE = 3 << 20
 
 Order = Literal["asc", "desc"]
 SortBy = Literal["created_at", "filename", "size"]
+
+
+def _expires_after_to_seconds(expires_after: Optional[Union[datetime.timedelta, int]]) -> Optional[int]:
+    """Convert an `expires_after` argument (timedelta or int seconds) to integer seconds, or None."""
+    if expires_after is None:
+        return None
+    if isinstance(expires_after, datetime.timedelta):
+        return int(expires_after.total_seconds())
+    return expires_after
 
 
 class ProgressBarLike(Protocol):
@@ -91,7 +101,10 @@ def _sort_by_to_pb(sort_by: SortBy | None) -> files_pb2.FilesSortBy:
 
 
 def _chunk_file_data(
-    filename: str, data: bytes, progress: ProgressCallback = None
+    filename: str,
+    data: bytes,
+    progress: ProgressCallback = None,
+    expires_after: Optional[Union[datetime.timedelta, int]] = None,
 ) -> Iterator[files_pb2.UploadFileChunk]:
     """Generator that yields file upload chunks.
 
@@ -101,6 +114,7 @@ def _chunk_file_data(
         filename: Name of the file being uploaded.
         data: The file data as bytes.
         progress: Optional progress callback or tqdm-like object.
+        expires_after: Optional expiration for the file (timedelta or int seconds).
 
     Yields:
         UploadFileChunk messages containing either init metadata or data.
@@ -109,7 +123,7 @@ def _chunk_file_data(
     yield files_pb2.UploadFileChunk(
         init=files_pb2.UploadFileInit(
             name=filename,
-            purpose="",  # Purpose is unused by backend
+            expires_after=_expires_after_to_seconds(expires_after),
         )
     )
 
@@ -127,7 +141,11 @@ def _chunk_file_data(
         _invoke_progress(progress, chunk_size, bytes_uploaded, total_bytes)
 
 
-def _chunk_file_from_path(file_path: str, progress: ProgressCallback = None) -> Iterator[files_pb2.UploadFileChunk]:
+def _chunk_file_from_path(
+    file_path: str,
+    progress: ProgressCallback = None,
+    expires_after: Optional[Union[datetime.timedelta, int]] = None,
+) -> Iterator[files_pb2.UploadFileChunk]:
     """Generator that yields file upload chunks by streaming from disk.
 
     This method reads the file in chunks rather than loading it entirely into memory,
@@ -136,6 +154,7 @@ def _chunk_file_from_path(file_path: str, progress: ProgressCallback = None) -> 
     Args:
         file_path: Path to the file to upload.
         progress: Optional progress callback or tqdm-like object.
+        expires_after: Optional expiration for the file (timedelta or int seconds).
 
     Yields:
         UploadFileChunk messages containing either init metadata or data.
@@ -148,7 +167,7 @@ def _chunk_file_from_path(file_path: str, progress: ProgressCallback = None) -> 
     yield files_pb2.UploadFileChunk(
         init=files_pb2.UploadFileInit(
             name=filename,
-            purpose="",  # Purpose is unused by backend
+            expires_after=_expires_after_to_seconds(expires_after),
         )
     )
 
@@ -164,7 +183,10 @@ def _chunk_file_from_path(file_path: str, progress: ProgressCallback = None) -> 
 
 
 def _chunk_file_from_fileobj(
-    file_obj: BinaryIO, filename: str, progress: ProgressCallback = None
+    file_obj: BinaryIO,
+    filename: str,
+    progress: ProgressCallback = None,
+    expires_after: Optional[Union[datetime.timedelta, int]] = None,
 ) -> Iterator[files_pb2.UploadFileChunk]:
     """Generator that yields file upload chunks from a file-like object.
 
@@ -172,6 +194,7 @@ def _chunk_file_from_fileobj(
         file_obj: Binary file-like object to read from.
         filename: Name to use for the uploaded file.
         progress: Optional progress callback or tqdm-like object.
+        expires_after: Optional expiration for the file (timedelta or int seconds).
 
     Yields:
         UploadFileChunk messages containing either init metadata or data.
@@ -192,7 +215,7 @@ def _chunk_file_from_fileobj(
     yield files_pb2.UploadFileChunk(
         init=files_pb2.UploadFileInit(
             name=filename,
-            purpose="",  # Purpose is unused by backend
+            expires_after=_expires_after_to_seconds(expires_after),
         )
     )
 
@@ -210,7 +233,10 @@ def _chunk_file_from_fileobj(
 
 
 async def _async_chunk_file_data(
-    filename: str, data: bytes, progress: ProgressCallback = None
+    filename: str,
+    data: bytes,
+    progress: ProgressCallback = None,
+    expires_after: Optional[Union[datetime.timedelta, int]] = None,
 ) -> AsyncIterator[files_pb2.UploadFileChunk]:
     """Async generator that yields file upload chunks.
 
@@ -220,6 +246,7 @@ async def _async_chunk_file_data(
         filename: Name of the file being uploaded.
         data: The file data as bytes.
         progress: Optional progress callback or tqdm-like object.
+        expires_after: Optional expiration for the file (timedelta or int seconds).
 
     Yields:
         UploadFileChunk messages containing either init metadata or data.
@@ -228,7 +255,7 @@ async def _async_chunk_file_data(
     yield files_pb2.UploadFileChunk(
         init=files_pb2.UploadFileInit(
             name=filename,
-            purpose="",  # Purpose is unused by backend
+            expires_after=_expires_after_to_seconds(expires_after),
         )
     )
 
@@ -247,7 +274,9 @@ async def _async_chunk_file_data(
 
 
 async def _async_chunk_file_from_path(
-    file_path: str, progress: ProgressCallback = None
+    file_path: str,
+    progress: ProgressCallback = None,
+    expires_after: Optional[Union[datetime.timedelta, int]] = None,
 ) -> AsyncIterator[files_pb2.UploadFileChunk]:
     """Async generator that yields file upload chunks by streaming from disk.
 
@@ -257,6 +286,7 @@ async def _async_chunk_file_from_path(
     Args:
         file_path: Path to the file to upload.
         progress: Optional progress callback or tqdm-like object.
+        expires_after: Optional expiration for the file (timedelta or int seconds).
 
     Yields:
         UploadFileChunk messages containing either init metadata or data.
@@ -269,7 +299,7 @@ async def _async_chunk_file_from_path(
     yield files_pb2.UploadFileChunk(
         init=files_pb2.UploadFileInit(
             name=filename,
-            purpose="",  # Purpose is unused by backend
+            expires_after=_expires_after_to_seconds(expires_after),
         )
     )
 
@@ -295,7 +325,10 @@ async def _async_chunk_file_from_path(
 
 
 async def _async_chunk_file_from_fileobj(
-    file_obj: BinaryIO, filename: str, progress: ProgressCallback = None
+    file_obj: BinaryIO,
+    filename: str,
+    progress: ProgressCallback = None,
+    expires_after: Optional[Union[datetime.timedelta, int]] = None,
 ) -> AsyncIterator[files_pb2.UploadFileChunk]:
     """Async generator that yields file upload chunks from a file-like object.
 
@@ -303,6 +336,7 @@ async def _async_chunk_file_from_fileobj(
         file_obj: Binary file-like object to read from.
         filename: Name to use for the uploaded file.
         progress: Optional progress callback or tqdm-like object.
+        expires_after: Optional expiration for the file (timedelta or int seconds).
 
     Yields:
         UploadFileChunk messages containing either init metadata or data.
@@ -323,7 +357,7 @@ async def _async_chunk_file_from_fileobj(
     yield files_pb2.UploadFileChunk(
         init=files_pb2.UploadFileInit(
             name=filename,
-            purpose="",  # Purpose is unused by backend
+            expires_after=_expires_after_to_seconds(expires_after),
         )
     )
 

--- a/src/xai_sdk/proto/v5/files_pb2.py
+++ b/src/xai_sdk/proto/v5/files_pb2.py
@@ -25,7 +25,7 @@ _sym_db = _symbol_database.Default()
 from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x16xai/api/v1/files.proto\x12\x07xai_api\x1a\x1fgoogle/protobuf/timestamp.proto\">\n\x0eUploadFileInit\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n\x07purpose\x18\x02 \x01(\tR\x07purpose\"_\n\x0fUploadFileChunk\x12-\n\x04init\x18\x01 \x01(\x0b\x32\x17.xai_api.UploadFileInitH\x00R\x04init\x12\x14\n\x04\x64\x61ta\x18\x02 \x01(\x0cH\x00R\x04\x64\x61taB\x07\n\x05\x63hunk\"\xe9\x01\n\x04\x46ile\x12\x12\n\x04size\x18\x01 \x01(\x03R\x04size\x12\x39\n\ncreated_at\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.TimestampR\tcreatedAt\x12>\n\nexpires_at\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.TimestampH\x00R\texpiresAt\x88\x01\x01\x12\x1a\n\x08\x66ilename\x18\x04 \x01(\tR\x08\x66ilename\x12\x0e\n\x02id\x18\x05 \x01(\tR\x02id\x12\x17\n\x07team_id\x18\x06 \x01(\tR\x06teamIdB\r\n\x0b_expires_at\"\xd6\x01\n\x10ListFilesRequest\x12\x14\n\x05limit\x18\x01 \x01(\x05R\x05limit\x12\'\n\x05order\x18\x02 \x01(\x0e\x32\x11.xai_api.OrderingR\x05order\x12.\n\x10pagination_token\x18\x03 \x01(\tH\x00R\x0fpaginationToken\x88\x01\x01\x12\x32\n\x07sort_by\x18\x04 \x01(\x0e\x32\x14.xai_api.FilesSortByH\x01R\x06sortBy\x88\x01\x01\x42\x13\n\x11_pagination_tokenB\n\n\x08_sort_by\"{\n\x11ListFilesResponse\x12!\n\x04\x64\x61ta\x18\x01 \x03(\x0b\x32\r.xai_api.FileR\x04\x64\x61ta\x12.\n\x10pagination_token\x18\x02 \x01(\tH\x00R\x0fpaginationToken\x88\x01\x01\x42\x13\n\x11_pagination_token\".\n\x13RetrieveFileRequest\x12\x17\n\x07\x66ile_id\x18\x01 \x01(\tR\x06\x66ileId\",\n\x11\x44\x65leteFileRequest\x12\x17\n\x07\x66ile_id\x18\x01 \x01(\tR\x06\x66ileId\">\n\x12\x44\x65leteFileResponse\x12\x0e\n\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n\x07\x64\x65leted\x18\x02 \x01(\x08R\x07\x64\x65leted\"5\n\x1aRetrieveFileContentRequest\x12\x17\n\x07\x66ile_id\x18\x01 \x01(\tR\x06\x66ileId\"&\n\x10\x46ileContentChunk\x12\x12\n\x04\x64\x61ta\x18\x01 \x01(\x0cR\x04\x64\x61ta\"1\n\x16RetrieveFileURLRequest\x12\x17\n\x07\x66ile_id\x18\x01 \x01(\tR\x06\x66ileId\"+\n\x17RetrieveFileURLResponse\x12\x10\n\x03url\x18\x01 \x01(\tR\x03url*)\n\x08Ordering\x12\r\n\tASCENDING\x10\x00\x12\x0e\n\nDESCENDING\x10\x01*_\n\x0b\x46ilesSortBy\x12\x1c\n\x18\x46ILES_SORT_BY_CREATED_AT\x10\x00\x12\x1a\n\x16\x46ILES_SORT_BY_FILENAME\x10\x01\x12\x16\n\x12\x46ILES_SORT_BY_SIZE\x10\x02\x32\xc3\x03\n\x05\x46iles\x12\x39\n\nUploadFile\x12\x18.xai_api.UploadFileChunk\x1a\r.xai_api.File\"\x00(\x01\x12\x44\n\tListFiles\x12\x19.xai_api.ListFilesRequest\x1a\x1a.xai_api.ListFilesResponse\"\x00\x12=\n\x0cRetrieveFile\x12\x1c.xai_api.RetrieveFileRequest\x1a\r.xai_api.File\"\x00\x12G\n\nDeleteFile\x12\x1a.xai_api.DeleteFileRequest\x1a\x1b.xai_api.DeleteFileResponse\"\x00\x12Y\n\x13RetrieveFileContent\x12#.xai_api.RetrieveFileContentRequest\x1a\x19.xai_api.FileContentChunk\"\x00\x30\x01\x12V\n\x0fRetrieveFileURL\x12\x1f.xai_api.RetrieveFileURLRequest\x1a .xai_api.RetrieveFileURLResponse\"\x00\x42Q\n\x0b\x63om.xai_apiB\nFilesProtoP\x01\xa2\x02\x03XXX\xaa\x02\x06XaiApi\xca\x02\x06XaiApi\xe2\x02\x12XaiApi\\GPBMetadata\xea\x02\x06XaiApib\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x16xai/api/v1/files.proto\x12\x07xai_api\x1a\x1fgoogle/protobuf/timestamp.proto\"`\n\x0eUploadFileInit\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12(\n\rexpires_after\x18\x02 \x01(\x03H\x00R\x0c\x65xpiresAfter\x88\x01\x01\x42\x10\n\x0e_expires_after\"_\n\x0fUploadFileChunk\x12-\n\x04init\x18\x01 \x01(\x0b\x32\x17.xai_api.UploadFileInitH\x00R\x04init\x12\x14\n\x04\x64\x61ta\x18\x02 \x01(\x0cH\x00R\x04\x64\x61taB\x07\n\x05\x63hunk\"\xd6\x01\n\x04\x46ile\x12\x12\n\x04size\x18\x01 \x01(\x03R\x04size\x12\x39\n\ncreated_at\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.TimestampR\tcreatedAt\x12>\n\nexpires_at\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.TimestampH\x00R\texpiresAt\x88\x01\x01\x12\x1a\n\x08\x66ilename\x18\x04 \x01(\tR\x08\x66ilename\x12\x0e\n\x02id\x18\x05 \x01(\tR\x02idB\r\n\x0b_expires_atJ\x04\x08\x06\x10\x07\"\xd6\x01\n\x10ListFilesRequest\x12\x14\n\x05limit\x18\x01 \x01(\x05R\x05limit\x12\'\n\x05order\x18\x02 \x01(\x0e\x32\x11.xai_api.OrderingR\x05order\x12.\n\x10pagination_token\x18\x03 \x01(\tH\x00R\x0fpaginationToken\x88\x01\x01\x12\x32\n\x07sort_by\x18\x04 \x01(\x0e\x32\x14.xai_api.FilesSortByH\x01R\x06sortBy\x88\x01\x01\x42\x13\n\x11_pagination_tokenB\n\n\x08_sort_by\"{\n\x11ListFilesResponse\x12!\n\x04\x64\x61ta\x18\x01 \x03(\x0b\x32\r.xai_api.FileR\x04\x64\x61ta\x12.\n\x10pagination_token\x18\x02 \x01(\tH\x00R\x0fpaginationToken\x88\x01\x01\x42\x13\n\x11_pagination_token\".\n\x13RetrieveFileRequest\x12\x17\n\x07\x66ile_id\x18\x01 \x01(\tR\x06\x66ileId\",\n\x11\x44\x65leteFileRequest\x12\x17\n\x07\x66ile_id\x18\x01 \x01(\tR\x06\x66ileId\">\n\x12\x44\x65leteFileResponse\x12\x0e\n\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n\x07\x64\x65leted\x18\x02 \x01(\x08R\x07\x64\x65leted\"v\n\x1aRetrieveFileContentRequest\x12\x17\n\x07\x66ile_id\x18\x01 \x01(\tR\x06\x66ileId\x12\x34\n\x06\x66ormat\x18\x02 \x01(\x0e\x32\x17.xai_api.DownloadFormatH\x00R\x06\x66ormat\x88\x01\x01\x42\t\n\x07_format\"&\n\x10\x46ileContentChunk\x12\x12\n\x04\x64\x61ta\x18\x01 \x01(\x0cR\x04\x64\x61ta*)\n\x08Ordering\x12\r\n\tASCENDING\x10\x00\x12\x0e\n\nDESCENDING\x10\x01*_\n\x0b\x46ilesSortBy\x12\x1c\n\x18\x46ILES_SORT_BY_CREATED_AT\x10\x00\x12\x1a\n\x16\x46ILES_SORT_BY_FILENAME\x10\x01\x12\x16\n\x12\x46ILES_SORT_BY_SIZE\x10\x02*e\n\x0e\x44ownloadFormat\x12\x1b\n\x17\x44OWNLOAD_FORMAT_UNKNOWN\x10\x00\x12\x1c\n\x18\x44OWNLOAD_FORMAT_ORIGINAL\x10\x01\x12\x18\n\x14\x44OWNLOAD_FORMAT_TEXT\x10\x02\x32\xeb\x02\n\x05\x46iles\x12\x39\n\nUploadFile\x12\x18.xai_api.UploadFileChunk\x1a\r.xai_api.File\"\x00(\x01\x12\x44\n\tListFiles\x12\x19.xai_api.ListFilesRequest\x1a\x1a.xai_api.ListFilesResponse\"\x00\x12=\n\x0cRetrieveFile\x12\x1c.xai_api.RetrieveFileRequest\x1a\r.xai_api.File\"\x00\x12G\n\nDeleteFile\x12\x1a.xai_api.DeleteFileRequest\x1a\x1b.xai_api.DeleteFileResponse\"\x00\x12Y\n\x13RetrieveFileContent\x12#.xai_api.RetrieveFileContentRequest\x1a\x19.xai_api.FileContentChunk\"\x00\x30\x01\x42Q\n\x0b\x63om.xai_apiB\nFilesProtoP\x01\xa2\x02\x03XXX\xaa\x02\x06XaiApi\xca\x02\x06XaiApi\xe2\x02\x12XaiApi\\GPBMetadata\xea\x02\x06XaiApib\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -33,34 +33,32 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'xai.api.v1.files_pb2', _glo
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'\n\013com.xai_apiB\nFilesProtoP\001\242\002\003XXX\252\002\006XaiApi\312\002\006XaiApi\342\002\022XaiApi\\GPBMetadata\352\002\006XaiApi'
-  _globals['_ORDERING']._serialized_start=1156
-  _globals['_ORDERING']._serialized_end=1197
-  _globals['_FILESSORTBY']._serialized_start=1199
-  _globals['_FILESSORTBY']._serialized_end=1294
+  _globals['_ORDERING']._serialized_start=1140
+  _globals['_ORDERING']._serialized_end=1181
+  _globals['_FILESSORTBY']._serialized_start=1183
+  _globals['_FILESSORTBY']._serialized_end=1278
+  _globals['_DOWNLOADFORMAT']._serialized_start=1280
+  _globals['_DOWNLOADFORMAT']._serialized_end=1381
   _globals['_UPLOADFILEINIT']._serialized_start=68
-  _globals['_UPLOADFILEINIT']._serialized_end=130
-  _globals['_UPLOADFILECHUNK']._serialized_start=132
-  _globals['_UPLOADFILECHUNK']._serialized_end=227
-  _globals['_FILE']._serialized_start=230
-  _globals['_FILE']._serialized_end=463
-  _globals['_LISTFILESREQUEST']._serialized_start=466
-  _globals['_LISTFILESREQUEST']._serialized_end=680
-  _globals['_LISTFILESRESPONSE']._serialized_start=682
-  _globals['_LISTFILESRESPONSE']._serialized_end=805
-  _globals['_RETRIEVEFILEREQUEST']._serialized_start=807
-  _globals['_RETRIEVEFILEREQUEST']._serialized_end=853
-  _globals['_DELETEFILEREQUEST']._serialized_start=855
-  _globals['_DELETEFILEREQUEST']._serialized_end=899
-  _globals['_DELETEFILERESPONSE']._serialized_start=901
-  _globals['_DELETEFILERESPONSE']._serialized_end=963
-  _globals['_RETRIEVEFILECONTENTREQUEST']._serialized_start=965
-  _globals['_RETRIEVEFILECONTENTREQUEST']._serialized_end=1018
-  _globals['_FILECONTENTCHUNK']._serialized_start=1020
-  _globals['_FILECONTENTCHUNK']._serialized_end=1058
-  _globals['_RETRIEVEFILEURLREQUEST']._serialized_start=1060
-  _globals['_RETRIEVEFILEURLREQUEST']._serialized_end=1109
-  _globals['_RETRIEVEFILEURLRESPONSE']._serialized_start=1111
-  _globals['_RETRIEVEFILEURLRESPONSE']._serialized_end=1154
-  _globals['_FILES']._serialized_start=1297
-  _globals['_FILES']._serialized_end=1748
+  _globals['_UPLOADFILEINIT']._serialized_end=164
+  _globals['_UPLOADFILECHUNK']._serialized_start=166
+  _globals['_UPLOADFILECHUNK']._serialized_end=261
+  _globals['_FILE']._serialized_start=264
+  _globals['_FILE']._serialized_end=478
+  _globals['_LISTFILESREQUEST']._serialized_start=481
+  _globals['_LISTFILESREQUEST']._serialized_end=695
+  _globals['_LISTFILESRESPONSE']._serialized_start=697
+  _globals['_LISTFILESRESPONSE']._serialized_end=820
+  _globals['_RETRIEVEFILEREQUEST']._serialized_start=822
+  _globals['_RETRIEVEFILEREQUEST']._serialized_end=868
+  _globals['_DELETEFILEREQUEST']._serialized_start=870
+  _globals['_DELETEFILEREQUEST']._serialized_end=914
+  _globals['_DELETEFILERESPONSE']._serialized_start=916
+  _globals['_DELETEFILERESPONSE']._serialized_end=978
+  _globals['_RETRIEVEFILECONTENTREQUEST']._serialized_start=980
+  _globals['_RETRIEVEFILECONTENTREQUEST']._serialized_end=1098
+  _globals['_FILECONTENTCHUNK']._serialized_start=1100
+  _globals['_FILECONTENTCHUNK']._serialized_end=1138
+  _globals['_FILES']._serialized_start=1384
+  _globals['_FILES']._serialized_end=1747
 # @@protoc_insertion_point(module_scope)

--- a/src/xai_sdk/proto/v5/files_pb2.pyi
+++ b/src/xai_sdk/proto/v5/files_pb2.pyi
@@ -17,19 +17,28 @@ class FilesSortBy(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
     FILES_SORT_BY_CREATED_AT: _ClassVar[FilesSortBy]
     FILES_SORT_BY_FILENAME: _ClassVar[FilesSortBy]
     FILES_SORT_BY_SIZE: _ClassVar[FilesSortBy]
+
+class DownloadFormat(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = ()
+    DOWNLOAD_FORMAT_UNKNOWN: _ClassVar[DownloadFormat]
+    DOWNLOAD_FORMAT_ORIGINAL: _ClassVar[DownloadFormat]
+    DOWNLOAD_FORMAT_TEXT: _ClassVar[DownloadFormat]
 ASCENDING: Ordering
 DESCENDING: Ordering
 FILES_SORT_BY_CREATED_AT: FilesSortBy
 FILES_SORT_BY_FILENAME: FilesSortBy
 FILES_SORT_BY_SIZE: FilesSortBy
+DOWNLOAD_FORMAT_UNKNOWN: DownloadFormat
+DOWNLOAD_FORMAT_ORIGINAL: DownloadFormat
+DOWNLOAD_FORMAT_TEXT: DownloadFormat
 
 class UploadFileInit(_message.Message):
-    __slots__ = ("name", "purpose")
+    __slots__ = ("name", "expires_after")
     NAME_FIELD_NUMBER: _ClassVar[int]
-    PURPOSE_FIELD_NUMBER: _ClassVar[int]
+    EXPIRES_AFTER_FIELD_NUMBER: _ClassVar[int]
     name: str
-    purpose: str
-    def __init__(self, name: _Optional[str] = ..., purpose: _Optional[str] = ...) -> None: ...
+    expires_after: int
+    def __init__(self, name: _Optional[str] = ..., expires_after: _Optional[int] = ...) -> None: ...
 
 class UploadFileChunk(_message.Message):
     __slots__ = ("init", "data")
@@ -40,20 +49,18 @@ class UploadFileChunk(_message.Message):
     def __init__(self, init: _Optional[_Union[UploadFileInit, _Mapping]] = ..., data: _Optional[bytes] = ...) -> None: ...
 
 class File(_message.Message):
-    __slots__ = ("size", "created_at", "expires_at", "filename", "id", "team_id")
+    __slots__ = ("size", "created_at", "expires_at", "filename", "id")
     SIZE_FIELD_NUMBER: _ClassVar[int]
     CREATED_AT_FIELD_NUMBER: _ClassVar[int]
     EXPIRES_AT_FIELD_NUMBER: _ClassVar[int]
     FILENAME_FIELD_NUMBER: _ClassVar[int]
     ID_FIELD_NUMBER: _ClassVar[int]
-    TEAM_ID_FIELD_NUMBER: _ClassVar[int]
     size: int
     created_at: _timestamp_pb2.Timestamp
     expires_at: _timestamp_pb2.Timestamp
     filename: str
     id: str
-    team_id: str
-    def __init__(self, size: _Optional[int] = ..., created_at: _Optional[_Union[_timestamp_pb2.Timestamp, _Mapping]] = ..., expires_at: _Optional[_Union[_timestamp_pb2.Timestamp, _Mapping]] = ..., filename: _Optional[str] = ..., id: _Optional[str] = ..., team_id: _Optional[str] = ...) -> None: ...
+    def __init__(self, size: _Optional[int] = ..., created_at: _Optional[_Union[_timestamp_pb2.Timestamp, _Mapping]] = ..., expires_at: _Optional[_Union[_timestamp_pb2.Timestamp, _Mapping]] = ..., filename: _Optional[str] = ..., id: _Optional[str] = ...) -> None: ...
 
 class ListFilesRequest(_message.Message):
     __slots__ = ("limit", "order", "pagination_token", "sort_by")
@@ -96,25 +103,15 @@ class DeleteFileResponse(_message.Message):
     def __init__(self, id: _Optional[str] = ..., deleted: bool = ...) -> None: ...
 
 class RetrieveFileContentRequest(_message.Message):
-    __slots__ = ("file_id",)
+    __slots__ = ("file_id", "format")
     FILE_ID_FIELD_NUMBER: _ClassVar[int]
+    FORMAT_FIELD_NUMBER: _ClassVar[int]
     file_id: str
-    def __init__(self, file_id: _Optional[str] = ...) -> None: ...
+    format: DownloadFormat
+    def __init__(self, file_id: _Optional[str] = ..., format: _Optional[_Union[DownloadFormat, str]] = ...) -> None: ...
 
 class FileContentChunk(_message.Message):
     __slots__ = ("data",)
     DATA_FIELD_NUMBER: _ClassVar[int]
     data: bytes
     def __init__(self, data: _Optional[bytes] = ...) -> None: ...
-
-class RetrieveFileURLRequest(_message.Message):
-    __slots__ = ("file_id",)
-    FILE_ID_FIELD_NUMBER: _ClassVar[int]
-    file_id: str
-    def __init__(self, file_id: _Optional[str] = ...) -> None: ...
-
-class RetrieveFileURLResponse(_message.Message):
-    __slots__ = ("url",)
-    URL_FIELD_NUMBER: _ClassVar[int]
-    url: str
-    def __init__(self, url: _Optional[str] = ...) -> None: ...

--- a/src/xai_sdk/proto/v5/files_pb2_grpc.py
+++ b/src/xai_sdk/proto/v5/files_pb2_grpc.py
@@ -6,7 +6,10 @@ from . import files_pb2 as xai_dot_api_dot_v1_dot_files__pb2
 
 
 class FilesStub(object):
-    """An API service for uploading and retrieving files.
+    """Service for uploading, listing, retrieving, and deleting files.
+
+    Files are referenced by the `id` returned on upload (e.g. when attaching
+    to chat completions). Maximum file size is 512 MB.
     """
 
     def __init__(self, channel):
@@ -40,54 +43,57 @@ class FilesStub(object):
                 request_serializer=xai_dot_api_dot_v1_dot_files__pb2.RetrieveFileContentRequest.SerializeToString,
                 response_deserializer=xai_dot_api_dot_v1_dot_files__pb2.FileContentChunk.FromString,
                 _registered_method=True)
-        self.RetrieveFileURL = channel.unary_unary(
-                '/xai_api.Files/RetrieveFileURL',
-                request_serializer=xai_dot_api_dot_v1_dot_files__pb2.RetrieveFileURLRequest.SerializeToString,
-                response_deserializer=xai_dot_api_dot_v1_dot_files__pb2.RetrieveFileURLResponse.FromString,
-                _registered_method=True)
 
 
 class FilesServicer(object):
-    """An API service for uploading and retrieving files.
+    """Service for uploading, listing, retrieving, and deleting files.
+
+    Files are referenced by the `id` returned on upload (e.g. when attaching
+    to chat completions). Maximum file size is 512 MB.
     """
 
     def UploadFile(self, request_iterator, context):
-        """Upload a file (client-streaming).
+        """Upload a file. The first stream message MUST set `chunk = init`
+        (filename + optional TTL); subsequent messages MUST set `chunk = data`
+        with file bytes in order. Recommended chunk size up to 5 MB; total
+        size capped at 512 MB. Returns the new file's metadata.
+
+        Errors: INVALID_ARGUMENT (missing/misplaced init, bad filename, bad
+        TTL), RESOURCE_EXHAUSTED (over 512 MB).
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
     def ListFiles(self, request, context):
-        """List files.
+        """List file metadata, paginated and sorted. Returns metadata only — use
+        `RetrieveFileContent` to download bytes.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
     def RetrieveFile(self, request, context):
-        """Retrieve file.
+        """Get metadata for one file. Returns metadata only — use
+        `RetrieveFileContent` to download bytes. Errors NOT_FOUND if no
+        accessible file with that id (including already-deleted).
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
     def DeleteFile(self, request, context):
-        """Delete file.
+        """Delete a file. After success it stops appearing in `ListFiles` /
+        `RetrieveFile` and is no longer downloadable. Errors NOT_FOUND if no
+        accessible file with that id (including already-deleted).
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
     def RetrieveFileContent(self, request, context):
-        """Retrieve file content (streams the file in chunks).
-        """
-        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details('Method not implemented!')
-        raise NotImplementedError('Method not implemented!')
-
-    def RetrieveFileURL(self, request, context):
-        """Retrieve presigned download URL for a file.
+        """Stream the file's contents in chunks of up to 5 MB, in order.
+        Concatenate `data` from every chunk to reconstruct the file.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
@@ -121,11 +127,6 @@ def add_FilesServicer_to_server(servicer, server):
                     request_deserializer=xai_dot_api_dot_v1_dot_files__pb2.RetrieveFileContentRequest.FromString,
                     response_serializer=xai_dot_api_dot_v1_dot_files__pb2.FileContentChunk.SerializeToString,
             ),
-            'RetrieveFileURL': grpc.unary_unary_rpc_method_handler(
-                    servicer.RetrieveFileURL,
-                    request_deserializer=xai_dot_api_dot_v1_dot_files__pb2.RetrieveFileURLRequest.FromString,
-                    response_serializer=xai_dot_api_dot_v1_dot_files__pb2.RetrieveFileURLResponse.SerializeToString,
-            ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
             'xai_api.Files', rpc_method_handlers)
@@ -135,7 +136,10 @@ def add_FilesServicer_to_server(servicer, server):
 
  # This class is part of an EXPERIMENTAL API.
 class Files(object):
-    """An API service for uploading and retrieving files.
+    """Service for uploading, listing, retrieving, and deleting files.
+
+    Files are referenced by the `id` returned on upload (e.g. when attaching
+    to chat completions). Maximum file size is 512 MB.
     """
 
     @staticmethod
@@ -263,33 +267,6 @@ class Files(object):
             '/xai_api.Files/RetrieveFileContent',
             xai_dot_api_dot_v1_dot_files__pb2.RetrieveFileContentRequest.SerializeToString,
             xai_dot_api_dot_v1_dot_files__pb2.FileContentChunk.FromString,
-            options,
-            channel_credentials,
-            insecure,
-            call_credentials,
-            compression,
-            wait_for_ready,
-            timeout,
-            metadata,
-            _registered_method=True)
-
-    @staticmethod
-    def RetrieveFileURL(request,
-            target,
-            options=(),
-            channel_credentials=None,
-            call_credentials=None,
-            insecure=False,
-            compression=None,
-            wait_for_ready=None,
-            timeout=None,
-            metadata=None):
-        return grpc.experimental.unary_unary(
-            request,
-            target,
-            '/xai_api.Files/RetrieveFileURL',
-            xai_dot_api_dot_v1_dot_files__pb2.RetrieveFileURLRequest.SerializeToString,
-            xai_dot_api_dot_v1_dot_files__pb2.RetrieveFileURLResponse.FromString,
             options,
             channel_credentials,
             insecure,

--- a/src/xai_sdk/proto/v6/files_pb2.py
+++ b/src/xai_sdk/proto/v6/files_pb2.py
@@ -25,7 +25,7 @@ _sym_db = _symbol_database.Default()
 from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x16xai/api/v1/files.proto\x12\x07xai_api\x1a\x1fgoogle/protobuf/timestamp.proto\">\n\x0eUploadFileInit\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12\x18\n\x07purpose\x18\x02 \x01(\tR\x07purpose\"_\n\x0fUploadFileChunk\x12-\n\x04init\x18\x01 \x01(\x0b\x32\x17.xai_api.UploadFileInitH\x00R\x04init\x12\x14\n\x04\x64\x61ta\x18\x02 \x01(\x0cH\x00R\x04\x64\x61taB\x07\n\x05\x63hunk\"\xe9\x01\n\x04\x46ile\x12\x12\n\x04size\x18\x01 \x01(\x03R\x04size\x12\x39\n\ncreated_at\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.TimestampR\tcreatedAt\x12>\n\nexpires_at\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.TimestampH\x00R\texpiresAt\x88\x01\x01\x12\x1a\n\x08\x66ilename\x18\x04 \x01(\tR\x08\x66ilename\x12\x0e\n\x02id\x18\x05 \x01(\tR\x02id\x12\x17\n\x07team_id\x18\x06 \x01(\tR\x06teamIdB\r\n\x0b_expires_at\"\xd6\x01\n\x10ListFilesRequest\x12\x14\n\x05limit\x18\x01 \x01(\x05R\x05limit\x12\'\n\x05order\x18\x02 \x01(\x0e\x32\x11.xai_api.OrderingR\x05order\x12.\n\x10pagination_token\x18\x03 \x01(\tH\x00R\x0fpaginationToken\x88\x01\x01\x12\x32\n\x07sort_by\x18\x04 \x01(\x0e\x32\x14.xai_api.FilesSortByH\x01R\x06sortBy\x88\x01\x01\x42\x13\n\x11_pagination_tokenB\n\n\x08_sort_by\"{\n\x11ListFilesResponse\x12!\n\x04\x64\x61ta\x18\x01 \x03(\x0b\x32\r.xai_api.FileR\x04\x64\x61ta\x12.\n\x10pagination_token\x18\x02 \x01(\tH\x00R\x0fpaginationToken\x88\x01\x01\x42\x13\n\x11_pagination_token\".\n\x13RetrieveFileRequest\x12\x17\n\x07\x66ile_id\x18\x01 \x01(\tR\x06\x66ileId\",\n\x11\x44\x65leteFileRequest\x12\x17\n\x07\x66ile_id\x18\x01 \x01(\tR\x06\x66ileId\">\n\x12\x44\x65leteFileResponse\x12\x0e\n\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n\x07\x64\x65leted\x18\x02 \x01(\x08R\x07\x64\x65leted\"5\n\x1aRetrieveFileContentRequest\x12\x17\n\x07\x66ile_id\x18\x01 \x01(\tR\x06\x66ileId\"&\n\x10\x46ileContentChunk\x12\x12\n\x04\x64\x61ta\x18\x01 \x01(\x0cR\x04\x64\x61ta\"1\n\x16RetrieveFileURLRequest\x12\x17\n\x07\x66ile_id\x18\x01 \x01(\tR\x06\x66ileId\"+\n\x17RetrieveFileURLResponse\x12\x10\n\x03url\x18\x01 \x01(\tR\x03url*)\n\x08Ordering\x12\r\n\tASCENDING\x10\x00\x12\x0e\n\nDESCENDING\x10\x01*_\n\x0b\x46ilesSortBy\x12\x1c\n\x18\x46ILES_SORT_BY_CREATED_AT\x10\x00\x12\x1a\n\x16\x46ILES_SORT_BY_FILENAME\x10\x01\x12\x16\n\x12\x46ILES_SORT_BY_SIZE\x10\x02\x32\xc3\x03\n\x05\x46iles\x12\x39\n\nUploadFile\x12\x18.xai_api.UploadFileChunk\x1a\r.xai_api.File\"\x00(\x01\x12\x44\n\tListFiles\x12\x19.xai_api.ListFilesRequest\x1a\x1a.xai_api.ListFilesResponse\"\x00\x12=\n\x0cRetrieveFile\x12\x1c.xai_api.RetrieveFileRequest\x1a\r.xai_api.File\"\x00\x12G\n\nDeleteFile\x12\x1a.xai_api.DeleteFileRequest\x1a\x1b.xai_api.DeleteFileResponse\"\x00\x12Y\n\x13RetrieveFileContent\x12#.xai_api.RetrieveFileContentRequest\x1a\x19.xai_api.FileContentChunk\"\x00\x30\x01\x12V\n\x0fRetrieveFileURL\x12\x1f.xai_api.RetrieveFileURLRequest\x1a .xai_api.RetrieveFileURLResponse\"\x00\x42Q\n\x0b\x63om.xai_apiB\nFilesProtoP\x01\xa2\x02\x03XXX\xaa\x02\x06XaiApi\xca\x02\x06XaiApi\xe2\x02\x12XaiApi\\GPBMetadata\xea\x02\x06XaiApib\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x16xai/api/v1/files.proto\x12\x07xai_api\x1a\x1fgoogle/protobuf/timestamp.proto\"`\n\x0eUploadFileInit\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12(\n\rexpires_after\x18\x02 \x01(\x03H\x00R\x0c\x65xpiresAfter\x88\x01\x01\x42\x10\n\x0e_expires_after\"_\n\x0fUploadFileChunk\x12-\n\x04init\x18\x01 \x01(\x0b\x32\x17.xai_api.UploadFileInitH\x00R\x04init\x12\x14\n\x04\x64\x61ta\x18\x02 \x01(\x0cH\x00R\x04\x64\x61taB\x07\n\x05\x63hunk\"\xd6\x01\n\x04\x46ile\x12\x12\n\x04size\x18\x01 \x01(\x03R\x04size\x12\x39\n\ncreated_at\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.TimestampR\tcreatedAt\x12>\n\nexpires_at\x18\x03 \x01(\x0b\x32\x1a.google.protobuf.TimestampH\x00R\texpiresAt\x88\x01\x01\x12\x1a\n\x08\x66ilename\x18\x04 \x01(\tR\x08\x66ilename\x12\x0e\n\x02id\x18\x05 \x01(\tR\x02idB\r\n\x0b_expires_atJ\x04\x08\x06\x10\x07\"\xd6\x01\n\x10ListFilesRequest\x12\x14\n\x05limit\x18\x01 \x01(\x05R\x05limit\x12\'\n\x05order\x18\x02 \x01(\x0e\x32\x11.xai_api.OrderingR\x05order\x12.\n\x10pagination_token\x18\x03 \x01(\tH\x00R\x0fpaginationToken\x88\x01\x01\x12\x32\n\x07sort_by\x18\x04 \x01(\x0e\x32\x14.xai_api.FilesSortByH\x01R\x06sortBy\x88\x01\x01\x42\x13\n\x11_pagination_tokenB\n\n\x08_sort_by\"{\n\x11ListFilesResponse\x12!\n\x04\x64\x61ta\x18\x01 \x03(\x0b\x32\r.xai_api.FileR\x04\x64\x61ta\x12.\n\x10pagination_token\x18\x02 \x01(\tH\x00R\x0fpaginationToken\x88\x01\x01\x42\x13\n\x11_pagination_token\".\n\x13RetrieveFileRequest\x12\x17\n\x07\x66ile_id\x18\x01 \x01(\tR\x06\x66ileId\",\n\x11\x44\x65leteFileRequest\x12\x17\n\x07\x66ile_id\x18\x01 \x01(\tR\x06\x66ileId\">\n\x12\x44\x65leteFileResponse\x12\x0e\n\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n\x07\x64\x65leted\x18\x02 \x01(\x08R\x07\x64\x65leted\"v\n\x1aRetrieveFileContentRequest\x12\x17\n\x07\x66ile_id\x18\x01 \x01(\tR\x06\x66ileId\x12\x34\n\x06\x66ormat\x18\x02 \x01(\x0e\x32\x17.xai_api.DownloadFormatH\x00R\x06\x66ormat\x88\x01\x01\x42\t\n\x07_format\"&\n\x10\x46ileContentChunk\x12\x12\n\x04\x64\x61ta\x18\x01 \x01(\x0cR\x04\x64\x61ta*)\n\x08Ordering\x12\r\n\tASCENDING\x10\x00\x12\x0e\n\nDESCENDING\x10\x01*_\n\x0b\x46ilesSortBy\x12\x1c\n\x18\x46ILES_SORT_BY_CREATED_AT\x10\x00\x12\x1a\n\x16\x46ILES_SORT_BY_FILENAME\x10\x01\x12\x16\n\x12\x46ILES_SORT_BY_SIZE\x10\x02*e\n\x0e\x44ownloadFormat\x12\x1b\n\x17\x44OWNLOAD_FORMAT_UNKNOWN\x10\x00\x12\x1c\n\x18\x44OWNLOAD_FORMAT_ORIGINAL\x10\x01\x12\x18\n\x14\x44OWNLOAD_FORMAT_TEXT\x10\x02\x32\xeb\x02\n\x05\x46iles\x12\x39\n\nUploadFile\x12\x18.xai_api.UploadFileChunk\x1a\r.xai_api.File\"\x00(\x01\x12\x44\n\tListFiles\x12\x19.xai_api.ListFilesRequest\x1a\x1a.xai_api.ListFilesResponse\"\x00\x12=\n\x0cRetrieveFile\x12\x1c.xai_api.RetrieveFileRequest\x1a\r.xai_api.File\"\x00\x12G\n\nDeleteFile\x12\x1a.xai_api.DeleteFileRequest\x1a\x1b.xai_api.DeleteFileResponse\"\x00\x12Y\n\x13RetrieveFileContent\x12#.xai_api.RetrieveFileContentRequest\x1a\x19.xai_api.FileContentChunk\"\x00\x30\x01\x42Q\n\x0b\x63om.xai_apiB\nFilesProtoP\x01\xa2\x02\x03XXX\xaa\x02\x06XaiApi\xca\x02\x06XaiApi\xe2\x02\x12XaiApi\\GPBMetadata\xea\x02\x06XaiApib\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -33,34 +33,32 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'xai.api.v1.files_pb2', _glo
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'\n\013com.xai_apiB\nFilesProtoP\001\242\002\003XXX\252\002\006XaiApi\312\002\006XaiApi\342\002\022XaiApi\\GPBMetadata\352\002\006XaiApi'
-  _globals['_ORDERING']._serialized_start=1156
-  _globals['_ORDERING']._serialized_end=1197
-  _globals['_FILESSORTBY']._serialized_start=1199
-  _globals['_FILESSORTBY']._serialized_end=1294
+  _globals['_ORDERING']._serialized_start=1140
+  _globals['_ORDERING']._serialized_end=1181
+  _globals['_FILESSORTBY']._serialized_start=1183
+  _globals['_FILESSORTBY']._serialized_end=1278
+  _globals['_DOWNLOADFORMAT']._serialized_start=1280
+  _globals['_DOWNLOADFORMAT']._serialized_end=1381
   _globals['_UPLOADFILEINIT']._serialized_start=68
-  _globals['_UPLOADFILEINIT']._serialized_end=130
-  _globals['_UPLOADFILECHUNK']._serialized_start=132
-  _globals['_UPLOADFILECHUNK']._serialized_end=227
-  _globals['_FILE']._serialized_start=230
-  _globals['_FILE']._serialized_end=463
-  _globals['_LISTFILESREQUEST']._serialized_start=466
-  _globals['_LISTFILESREQUEST']._serialized_end=680
-  _globals['_LISTFILESRESPONSE']._serialized_start=682
-  _globals['_LISTFILESRESPONSE']._serialized_end=805
-  _globals['_RETRIEVEFILEREQUEST']._serialized_start=807
-  _globals['_RETRIEVEFILEREQUEST']._serialized_end=853
-  _globals['_DELETEFILEREQUEST']._serialized_start=855
-  _globals['_DELETEFILEREQUEST']._serialized_end=899
-  _globals['_DELETEFILERESPONSE']._serialized_start=901
-  _globals['_DELETEFILERESPONSE']._serialized_end=963
-  _globals['_RETRIEVEFILECONTENTREQUEST']._serialized_start=965
-  _globals['_RETRIEVEFILECONTENTREQUEST']._serialized_end=1018
-  _globals['_FILECONTENTCHUNK']._serialized_start=1020
-  _globals['_FILECONTENTCHUNK']._serialized_end=1058
-  _globals['_RETRIEVEFILEURLREQUEST']._serialized_start=1060
-  _globals['_RETRIEVEFILEURLREQUEST']._serialized_end=1109
-  _globals['_RETRIEVEFILEURLRESPONSE']._serialized_start=1111
-  _globals['_RETRIEVEFILEURLRESPONSE']._serialized_end=1154
-  _globals['_FILES']._serialized_start=1297
-  _globals['_FILES']._serialized_end=1748
+  _globals['_UPLOADFILEINIT']._serialized_end=164
+  _globals['_UPLOADFILECHUNK']._serialized_start=166
+  _globals['_UPLOADFILECHUNK']._serialized_end=261
+  _globals['_FILE']._serialized_start=264
+  _globals['_FILE']._serialized_end=478
+  _globals['_LISTFILESREQUEST']._serialized_start=481
+  _globals['_LISTFILESREQUEST']._serialized_end=695
+  _globals['_LISTFILESRESPONSE']._serialized_start=697
+  _globals['_LISTFILESRESPONSE']._serialized_end=820
+  _globals['_RETRIEVEFILEREQUEST']._serialized_start=822
+  _globals['_RETRIEVEFILEREQUEST']._serialized_end=868
+  _globals['_DELETEFILEREQUEST']._serialized_start=870
+  _globals['_DELETEFILEREQUEST']._serialized_end=914
+  _globals['_DELETEFILERESPONSE']._serialized_start=916
+  _globals['_DELETEFILERESPONSE']._serialized_end=978
+  _globals['_RETRIEVEFILECONTENTREQUEST']._serialized_start=980
+  _globals['_RETRIEVEFILECONTENTREQUEST']._serialized_end=1098
+  _globals['_FILECONTENTCHUNK']._serialized_start=1100
+  _globals['_FILECONTENTCHUNK']._serialized_end=1138
+  _globals['_FILES']._serialized_start=1384
+  _globals['_FILES']._serialized_end=1747
 # @@protoc_insertion_point(module_scope)

--- a/src/xai_sdk/proto/v6/files_pb2.pyi
+++ b/src/xai_sdk/proto/v6/files_pb2.pyi
@@ -18,19 +18,28 @@ class FilesSortBy(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
     FILES_SORT_BY_CREATED_AT: _ClassVar[FilesSortBy]
     FILES_SORT_BY_FILENAME: _ClassVar[FilesSortBy]
     FILES_SORT_BY_SIZE: _ClassVar[FilesSortBy]
+
+class DownloadFormat(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = ()
+    DOWNLOAD_FORMAT_UNKNOWN: _ClassVar[DownloadFormat]
+    DOWNLOAD_FORMAT_ORIGINAL: _ClassVar[DownloadFormat]
+    DOWNLOAD_FORMAT_TEXT: _ClassVar[DownloadFormat]
 ASCENDING: Ordering
 DESCENDING: Ordering
 FILES_SORT_BY_CREATED_AT: FilesSortBy
 FILES_SORT_BY_FILENAME: FilesSortBy
 FILES_SORT_BY_SIZE: FilesSortBy
+DOWNLOAD_FORMAT_UNKNOWN: DownloadFormat
+DOWNLOAD_FORMAT_ORIGINAL: DownloadFormat
+DOWNLOAD_FORMAT_TEXT: DownloadFormat
 
 class UploadFileInit(_message.Message):
-    __slots__ = ("name", "purpose")
+    __slots__ = ("name", "expires_after")
     NAME_FIELD_NUMBER: _ClassVar[int]
-    PURPOSE_FIELD_NUMBER: _ClassVar[int]
+    EXPIRES_AFTER_FIELD_NUMBER: _ClassVar[int]
     name: str
-    purpose: str
-    def __init__(self, name: _Optional[str] = ..., purpose: _Optional[str] = ...) -> None: ...
+    expires_after: int
+    def __init__(self, name: _Optional[str] = ..., expires_after: _Optional[int] = ...) -> None: ...
 
 class UploadFileChunk(_message.Message):
     __slots__ = ("init", "data")
@@ -41,20 +50,18 @@ class UploadFileChunk(_message.Message):
     def __init__(self, init: _Optional[_Union[UploadFileInit, _Mapping]] = ..., data: _Optional[bytes] = ...) -> None: ...
 
 class File(_message.Message):
-    __slots__ = ("size", "created_at", "expires_at", "filename", "id", "team_id")
+    __slots__ = ("size", "created_at", "expires_at", "filename", "id")
     SIZE_FIELD_NUMBER: _ClassVar[int]
     CREATED_AT_FIELD_NUMBER: _ClassVar[int]
     EXPIRES_AT_FIELD_NUMBER: _ClassVar[int]
     FILENAME_FIELD_NUMBER: _ClassVar[int]
     ID_FIELD_NUMBER: _ClassVar[int]
-    TEAM_ID_FIELD_NUMBER: _ClassVar[int]
     size: int
     created_at: _timestamp_pb2.Timestamp
     expires_at: _timestamp_pb2.Timestamp
     filename: str
     id: str
-    team_id: str
-    def __init__(self, size: _Optional[int] = ..., created_at: _Optional[_Union[_timestamp_pb2.Timestamp, _Mapping]] = ..., expires_at: _Optional[_Union[_timestamp_pb2.Timestamp, _Mapping]] = ..., filename: _Optional[str] = ..., id: _Optional[str] = ..., team_id: _Optional[str] = ...) -> None: ...
+    def __init__(self, size: _Optional[int] = ..., created_at: _Optional[_Union[_timestamp_pb2.Timestamp, _Mapping]] = ..., expires_at: _Optional[_Union[_timestamp_pb2.Timestamp, _Mapping]] = ..., filename: _Optional[str] = ..., id: _Optional[str] = ...) -> None: ...
 
 class ListFilesRequest(_message.Message):
     __slots__ = ("limit", "order", "pagination_token", "sort_by")
@@ -97,25 +104,15 @@ class DeleteFileResponse(_message.Message):
     def __init__(self, id: _Optional[str] = ..., deleted: bool = ...) -> None: ...
 
 class RetrieveFileContentRequest(_message.Message):
-    __slots__ = ("file_id",)
+    __slots__ = ("file_id", "format")
     FILE_ID_FIELD_NUMBER: _ClassVar[int]
+    FORMAT_FIELD_NUMBER: _ClassVar[int]
     file_id: str
-    def __init__(self, file_id: _Optional[str] = ...) -> None: ...
+    format: DownloadFormat
+    def __init__(self, file_id: _Optional[str] = ..., format: _Optional[_Union[DownloadFormat, str]] = ...) -> None: ...
 
 class FileContentChunk(_message.Message):
     __slots__ = ("data",)
     DATA_FIELD_NUMBER: _ClassVar[int]
     data: bytes
     def __init__(self, data: _Optional[bytes] = ...) -> None: ...
-
-class RetrieveFileURLRequest(_message.Message):
-    __slots__ = ("file_id",)
-    FILE_ID_FIELD_NUMBER: _ClassVar[int]
-    file_id: str
-    def __init__(self, file_id: _Optional[str] = ...) -> None: ...
-
-class RetrieveFileURLResponse(_message.Message):
-    __slots__ = ("url",)
-    URL_FIELD_NUMBER: _ClassVar[int]
-    url: str
-    def __init__(self, url: _Optional[str] = ...) -> None: ...

--- a/src/xai_sdk/proto/v6/files_pb2_grpc.py
+++ b/src/xai_sdk/proto/v6/files_pb2_grpc.py
@@ -6,7 +6,10 @@ from . import files_pb2 as xai_dot_api_dot_v1_dot_files__pb2
 
 
 class FilesStub(object):
-    """An API service for uploading and retrieving files.
+    """Service for uploading, listing, retrieving, and deleting files.
+
+    Files are referenced by the `id` returned on upload (e.g. when attaching
+    to chat completions). Maximum file size is 512 MB.
     """
 
     def __init__(self, channel):
@@ -40,54 +43,57 @@ class FilesStub(object):
                 request_serializer=xai_dot_api_dot_v1_dot_files__pb2.RetrieveFileContentRequest.SerializeToString,
                 response_deserializer=xai_dot_api_dot_v1_dot_files__pb2.FileContentChunk.FromString,
                 _registered_method=True)
-        self.RetrieveFileURL = channel.unary_unary(
-                '/xai_api.Files/RetrieveFileURL',
-                request_serializer=xai_dot_api_dot_v1_dot_files__pb2.RetrieveFileURLRequest.SerializeToString,
-                response_deserializer=xai_dot_api_dot_v1_dot_files__pb2.RetrieveFileURLResponse.FromString,
-                _registered_method=True)
 
 
 class FilesServicer(object):
-    """An API service for uploading and retrieving files.
+    """Service for uploading, listing, retrieving, and deleting files.
+
+    Files are referenced by the `id` returned on upload (e.g. when attaching
+    to chat completions). Maximum file size is 512 MB.
     """
 
     def UploadFile(self, request_iterator, context):
-        """Upload a file (client-streaming).
+        """Upload a file. The first stream message MUST set `chunk = init`
+        (filename + optional TTL); subsequent messages MUST set `chunk = data`
+        with file bytes in order. Recommended chunk size up to 5 MB; total
+        size capped at 512 MB. Returns the new file's metadata.
+
+        Errors: INVALID_ARGUMENT (missing/misplaced init, bad filename, bad
+        TTL), RESOURCE_EXHAUSTED (over 512 MB).
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
     def ListFiles(self, request, context):
-        """List files.
+        """List file metadata, paginated and sorted. Returns metadata only — use
+        `RetrieveFileContent` to download bytes.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
     def RetrieveFile(self, request, context):
-        """Retrieve file.
+        """Get metadata for one file. Returns metadata only — use
+        `RetrieveFileContent` to download bytes. Errors NOT_FOUND if no
+        accessible file with that id (including already-deleted).
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
     def DeleteFile(self, request, context):
-        """Delete file.
+        """Delete a file. After success it stops appearing in `ListFiles` /
+        `RetrieveFile` and is no longer downloadable. Errors NOT_FOUND if no
+        accessible file with that id (including already-deleted).
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
     def RetrieveFileContent(self, request, context):
-        """Retrieve file content (streams the file in chunks).
-        """
-        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
-        context.set_details('Method not implemented!')
-        raise NotImplementedError('Method not implemented!')
-
-    def RetrieveFileURL(self, request, context):
-        """Retrieve presigned download URL for a file.
+        """Stream the file's contents in chunks of up to 5 MB, in order.
+        Concatenate `data` from every chunk to reconstruct the file.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
@@ -121,11 +127,6 @@ def add_FilesServicer_to_server(servicer, server):
                     request_deserializer=xai_dot_api_dot_v1_dot_files__pb2.RetrieveFileContentRequest.FromString,
                     response_serializer=xai_dot_api_dot_v1_dot_files__pb2.FileContentChunk.SerializeToString,
             ),
-            'RetrieveFileURL': grpc.unary_unary_rpc_method_handler(
-                    servicer.RetrieveFileURL,
-                    request_deserializer=xai_dot_api_dot_v1_dot_files__pb2.RetrieveFileURLRequest.FromString,
-                    response_serializer=xai_dot_api_dot_v1_dot_files__pb2.RetrieveFileURLResponse.SerializeToString,
-            ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
             'xai_api.Files', rpc_method_handlers)
@@ -135,7 +136,10 @@ def add_FilesServicer_to_server(servicer, server):
 
  # This class is part of an EXPERIMENTAL API.
 class Files(object):
-    """An API service for uploading and retrieving files.
+    """Service for uploading, listing, retrieving, and deleting files.
+
+    Files are referenced by the `id` returned on upload (e.g. when attaching
+    to chat completions). Maximum file size is 512 MB.
     """
 
     @staticmethod
@@ -263,33 +267,6 @@ class Files(object):
             '/xai_api.Files/RetrieveFileContent',
             xai_dot_api_dot_v1_dot_files__pb2.RetrieveFileContentRequest.SerializeToString,
             xai_dot_api_dot_v1_dot_files__pb2.FileContentChunk.FromString,
-            options,
-            channel_credentials,
-            insecure,
-            call_credentials,
-            compression,
-            wait_for_ready,
-            timeout,
-            metadata,
-            _registered_method=True)
-
-    @staticmethod
-    def RetrieveFileURL(request,
-            target,
-            options=(),
-            channel_credentials=None,
-            call_credentials=None,
-            insecure=False,
-            compression=None,
-            wait_for_ready=None,
-            timeout=None,
-            metadata=None):
-        return grpc.experimental.unary_unary(
-            request,
-            target,
-            '/xai_api.Files/RetrieveFileURL',
-            xai_dot_api_dot_v1_dot_files__pb2.RetrieveFileURLRequest.SerializeToString,
-            xai_dot_api_dot_v1_dot_files__pb2.RetrieveFileURLResponse.FromString,
             options,
             channel_credentials,
             insecure,

--- a/src/xai_sdk/sync/files.py
+++ b/src/xai_sdk/sync/files.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import BinaryIO, Optional, Sequence, Union
@@ -32,6 +33,7 @@ class Client(BaseClient):
         *,
         filename: Optional[str] = None,
         on_progress: Optional[ProgressCallback] = None,
+        expires_after: Optional[Union[datetime.timedelta, int]] = None,
     ) -> files_pb2.File:
         """Upload a file to xAI's servers.
 
@@ -54,6 +56,12 @@ class Client(BaseClient):
                   Called with the size of the chunk just uploaded (e.g., tqdm.update).
                 - An object with an `update(n: int)` method (e.g., tqdm progress bar).
                   The update method is called with the chunk size after each upload.
+            expires_after: Optional time-to-live for the file, measured from the moment of upload (creation).
+                After this duration the file is automatically deleted.
+                Can be:
+                - datetime.timedelta: Duration after upload (e.g., timedelta(hours=24)).
+                - int: Number of seconds after upload.
+                If not provided, the file does not expire.
 
         Returns:
             A File proto containing metadata about the uploaded file.
@@ -92,13 +100,22 @@ class Client(BaseClient):
         if isinstance(file, str):
             if not os.path.exists(file):
                 raise FileNotFoundError(f"File not found: {file}")
-            chunks = _chunk_file_from_path(file_path=file, progress=on_progress)
+            chunks = _chunk_file_from_path(
+                file_path=file,
+                progress=on_progress,
+                expires_after=expires_after,
+            )
 
         # Handle bytes
         elif isinstance(file, bytes | bytearray):
             if not filename:
                 raise ValueError("filename is required when uploading bytes")
-            chunks = _chunk_file_data(filename=filename, data=bytes(file), progress=on_progress)
+            chunks = _chunk_file_data(
+                filename=filename,
+                data=bytes(file),
+                progress=on_progress,
+                expires_after=expires_after,
+            )
 
         # Handle file-like object (BinaryIO)
         elif hasattr(file, "read"):
@@ -108,7 +125,12 @@ class Client(BaseClient):
                     filename = os.path.basename(file.name)
                 else:
                     raise ValueError("filename is required when uploading a file-like object without a .name attribute")
-            chunks = _chunk_file_from_fileobj(file_obj=file, filename=filename, progress=on_progress)
+            chunks = _chunk_file_from_fileobj(
+                file_obj=file,
+                filename=filename,
+                progress=on_progress,
+                expires_after=expires_after,
+            )
         else:
             raise ValueError(f"Unsupported file type: {type(file)}")
         with tracer.start_as_current_span(

--- a/tests/aio/files_test.py
+++ b/tests/aio/files_test.py
@@ -1,5 +1,6 @@
 """Unit tests for asynchronous Files API client."""
 
+import datetime
 import io
 import os
 import tempfile
@@ -44,7 +45,6 @@ async def test_upload_file(client_with_mock_stub: AsyncClient, mock_stub):
             id="file-123",
             filename="test.txt",
             size=12,
-            team_id="team-456",
         )
 
         # Create async mock
@@ -63,7 +63,6 @@ async def test_upload_file(client_with_mock_stub: AsyncClient, mock_stub):
         assert result.id == "file-123"
         assert result.filename == "test.txt"
         assert result.size == 12
-        assert result.team_id == "team-456"
     finally:
         os.unlink(temp_file_path)
 
@@ -86,7 +85,6 @@ async def test_upload_bytes(client_with_mock_stub: AsyncClient, mock_stub):
         id="file-123",
         filename=filename,
         size=len(data),
-        team_id="team-456",
     )
 
     async def async_return():
@@ -113,7 +111,6 @@ async def test_upload_file_object(client_with_mock_stub: AsyncClient, mock_stub)
         id="file-789",
         filename="stream.txt",
         size=30,
-        team_id="team-abc",
     )
 
     async def async_return():
@@ -152,7 +149,6 @@ async def test_upload_with_progress_callback(client_with_mock_stub: AsyncClient,
             id="file-123",
             filename="test.txt",
             size=data_size,
-            team_id="team-456",
         )
 
         # Track progress calls
@@ -198,7 +194,6 @@ async def test_upload_with_progress_tqdm_like(client_with_mock_stub: AsyncClient
         id="file-456",
         filename="test.bin",
         size=len(data),
-        team_id="team-789",
     )
 
     # Create a mock tqdm-like object
@@ -314,7 +309,6 @@ async def test_get_file(client_with_mock_stub: AsyncClient, mock_stub):
         id="file-123",
         filename="test.txt",
         size=100,
-        team_id="team-456",
         created_at=created_at,
     )
 
@@ -398,7 +392,6 @@ def test_chunk_file_from_path():
         # First chunk should be the init chunk
         assert chunks[0].HasField("init")
         assert chunks[0].init.name.startswith("tmp")  # basename starts with tmp
-        assert chunks[0].init.purpose == ""  # Purpose is unused by backend
 
         # Subsequent chunks should be data chunks
         assert len(chunks) == 5  # 1 init + 4 data chunks (3 MiB, 3 MiB, 3 MiB, 3 MiB)
@@ -435,7 +428,6 @@ async def test_upload_large_file_uses_chunking(client_with_mock_stub: AsyncClien
             id="file-large",
             filename="large.bin",
             size=len(data),
-            team_id="team-456",
         )
 
         # Track chunks and return response
@@ -488,7 +480,6 @@ async def test_batch_upload_success(client_with_mock_stub: AsyncClient, mock_stu
                 id=file_id,
                 filename=f"batch_{call_count - 1}.txt",
                 size=100,
-                team_id="team-456",
             )
 
         mock_stub.UploadFile.side_effect = mock_upload
@@ -504,7 +495,6 @@ async def test_batch_upload_success(client_with_mock_stub: AsyncClient, mock_stu
         for idx, result in results.items():
             assert not isinstance(result, BaseException)
             assert result.id == f"file-{idx}"
-            assert result.team_id == "team-456"
 
     finally:
         for temp_file in temp_files:
@@ -539,7 +529,6 @@ async def test_batch_upload_with_partial_failures(client_with_mock_stub: AsyncCl
                 id=f"file-{idx}",
                 filename=f"batch_{idx}.txt",
                 size=100,
-                team_id="team-456",
             )
 
         mock_stub.UploadFile.side_effect = mock_upload
@@ -590,7 +579,6 @@ async def test_batch_upload_with_callback(client_with_mock_stub: AsyncClient, mo
                 id=file_id,
                 filename=f"batch_{call_count - 1}.txt",
                 size=100,
-                team_id="team-456",
             )
 
         mock_stub.UploadFile.side_effect = mock_upload
@@ -650,7 +638,6 @@ async def test_batch_upload_with_callback_and_failures(client_with_mock_stub: As
                 id=f"file-{idx}",
                 filename=f"batch_{idx}.txt",
                 size=100,
-                team_id="team-456",
             )
 
         mock_stub.UploadFile.side_effect = mock_upload
@@ -708,7 +695,6 @@ async def test_batch_upload_custom_batch_size(client_with_mock_stub: AsyncClient
                 id=file_id,
                 filename=f"batch_{call_count - 1}.txt",
                 size=100,
-                team_id="team-456",
             )
 
         mock_stub.UploadFile.side_effect = mock_upload
@@ -740,7 +726,7 @@ async def test_upload_creates_span_with_correct_attributes(
     mock_span = mock.MagicMock()
     mock_tracer.start_as_current_span.return_value.__enter__.return_value = mock_span
 
-    mock_response = files_pb2.File(id="file-123", filename="test.txt", size=12, team_id="team-456")
+    mock_response = files_pb2.File(id="file-123", filename="test.txt", size=12)
 
     async def async_return():
         return mock_response
@@ -790,3 +776,55 @@ async def test_delete_creates_span_with_correct_attributes(
 
     mock_span.set_attribute.assert_called_once_with("file.id", result.id)
     assert result.deleted is True
+
+
+@pytest.mark.asyncio
+async def test_upload_with_expires_after_int(client_with_mock_stub: AsyncClient, mock_stub):
+    """Test uploading a file with expires_after as int seconds."""
+    data = b"test content"
+    filename = "test.txt"
+
+    mock_response = files_pb2.File(
+        id="file-123",
+        filename=filename,
+        size=len(data),
+    )
+
+    async def consume_chunks(chunks):
+        chunk_list = []
+        async for chunk in chunks:
+            chunk_list.append(chunk)
+        assert chunk_list[0].HasField("init")
+        assert chunk_list[0].init.expires_after == 7200
+        return mock_response
+
+    mock_stub.UploadFile.side_effect = consume_chunks
+
+    result = await client_with_mock_stub.files.upload(data, filename=filename, expires_after=7200)
+    assert result.id == "file-123"
+
+
+@pytest.mark.asyncio
+async def test_upload_with_expires_after_timedelta(client_with_mock_stub: AsyncClient, mock_stub):
+    """Test uploading a file with expires_after as timedelta."""
+    data = b"test content"
+    filename = "test.txt"
+
+    mock_response = files_pb2.File(
+        id="file-123",
+        filename=filename,
+        size=len(data),
+    )
+
+    async def consume_chunks(chunks):
+        chunk_list = []
+        async for chunk in chunks:
+            chunk_list.append(chunk)
+        assert chunk_list[0].HasField("init")
+        assert chunk_list[0].init.expires_after == 86400
+        return mock_response
+
+    mock_stub.UploadFile.side_effect = consume_chunks
+
+    result = await client_with_mock_stub.files.upload(data, filename=filename, expires_after=datetime.timedelta(days=1))
+    assert result.id == "file-123"

--- a/tests/server.py
+++ b/tests/server.py
@@ -844,7 +844,6 @@ class FilesServicer(files_pb2_grpc.FilesServicer):
             id=file_id,
             filename=init.name,
             size=len(data),
-            team_id="test-team",
             created_at=now,
             expires_at=timestamp_pb2.Timestamp(seconds=int(time.time()) + 1000),
         )

--- a/tests/sync/files_test.py
+++ b/tests/sync/files_test.py
@@ -1,5 +1,6 @@
 """Unit tests for synchronous Files API client."""
 
+import datetime
 import io
 import os
 import tempfile
@@ -11,7 +12,12 @@ from google.protobuf import timestamp_pb2
 from opentelemetry.trace import SpanKind
 
 from xai_sdk import Client
-from xai_sdk.files import _chunk_file_data, _chunk_file_from_path, _order_to_pb, _sort_by_to_pb
+from xai_sdk.files import (
+    _chunk_file_data,
+    _chunk_file_from_path,
+    _order_to_pb,
+    _sort_by_to_pb,
+)
 from xai_sdk.proto import files_pb2
 
 
@@ -54,7 +60,6 @@ def create_mock_upload_handler(
             id=f"file-{idx}",
             filename=f"batch_{idx}.txt",
             size=100,
-            team_id="team-456",
         )
 
     return mock_upload
@@ -89,7 +94,6 @@ def test_upload_file(client_with_mock_stub: Client, mock_stub):
             id="file-123",
             filename="test.txt",
             size=12,
-            team_id="team-456",
         )
         mock_stub.UploadFile.return_value = mock_response
 
@@ -103,7 +107,6 @@ def test_upload_file(client_with_mock_stub: Client, mock_stub):
         assert result.id == "file-123"
         assert result.filename == "test.txt"
         assert result.size == 12
-        assert result.team_id == "team-456"
     finally:
         os.unlink(temp_file_path)
 
@@ -124,7 +127,6 @@ def test_upload_bytes(client_with_mock_stub: Client, mock_stub):
         id="file-123",
         filename=filename,
         size=len(data),
-        team_id="team-456",
     )
     mock_stub.UploadFile.return_value = mock_response
 
@@ -146,7 +148,6 @@ def test_upload_file_object(client_with_mock_stub: Client, mock_stub):
         id="file-789",
         filename="stream.txt",
         size=30,
-        team_id="team-abc",
     )
     mock_stub.UploadFile.return_value = mock_response
 
@@ -180,7 +181,6 @@ def test_upload_with_progress_callback(client_with_mock_stub: Client, mock_stub)
             id="file-123",
             filename="test.txt",
             size=data_size,
-            team_id="team-456",
         )
 
         # Track progress calls
@@ -225,7 +225,6 @@ def test_upload_with_progress_tqdm_like(client_with_mock_stub: Client, mock_stub
         id="file-456",
         filename="test.bin",
         size=len(data),
-        team_id="team-789",
     )
 
     # Create a mock tqdm-like object
@@ -325,7 +324,6 @@ def test_get_file(client_with_mock_stub: Client, mock_stub):
         id="file-123",
         filename="test.txt",
         size=100,
-        team_id="team-456",
         created_at=created_at,
     )
     mock_stub.RetrieveFile.return_value = mock_response
@@ -407,7 +405,6 @@ def test_chunk_file_data():
     # First chunk should be the init chunk
     assert chunks[0].HasField("init")
     assert chunks[0].init.name == filename
-    assert chunks[0].init.purpose == ""  # Purpose is unused by backend
 
     # Subsequent chunks should be data chunks
     assert len(chunks) == 2  # 1 init + 1 data chunk (2 MiB fits in one 5 MiB chunk)
@@ -432,7 +429,6 @@ def test_chunk_file_from_path():
         # First chunk should be the init chunk
         assert chunks[0].HasField("init")
         assert chunks[0].init.name.startswith("tmp")  # basename starts with tmp
-        assert chunks[0].init.purpose == ""  # Purpose is unused by backend
 
         # Subsequent chunks should be data chunks
         assert len(chunks) == 5  # 1 init + 4 data chunks (3 MiB, 3 MiB, 3 MiB, 3 MiB)
@@ -468,7 +464,6 @@ def test_upload_large_file_uses_chunking(client_with_mock_stub: Client, mock_stu
             id="file-large",
             filename="large.bin",
             size=len(data),
-            team_id="team-456",
         )
         mock_stub.UploadFile.return_value = mock_response
 
@@ -516,7 +511,6 @@ def test_batch_upload_success(client_with_mock_stub: Client, mock_stub):
         for idx, result in results.items():
             assert not isinstance(result, BaseException)
             assert result.id == f"file-{idx}"
-            assert result.team_id == "team-456"
 
     finally:
         for temp_file in temp_files:
@@ -678,7 +672,7 @@ def test_upload_creates_span_with_correct_attributes(
     mock_span = mock.MagicMock()
     mock_tracer.start_as_current_span.return_value.__enter__.return_value = mock_span
 
-    mock_response = files_pb2.File(id="file-123", filename="test.txt", size=12, team_id="team-456")
+    mock_response = files_pb2.File(id="file-123", filename="test.txt", size=12)
     mock_stub.UploadFile.return_value = mock_response
 
     result = client_with_mock_stub.files.upload(b"data", filename="test.txt")
@@ -719,3 +713,49 @@ def test_delete_creates_span_with_correct_attributes(
 
     mock_span.set_attribute.assert_called_once_with("file.id", result.id)
     assert result.deleted is True
+
+
+def test_upload_with_expires_after_int(client_with_mock_stub: Client, mock_stub):
+    """Test uploading a file with expires_after as int seconds."""
+    data = b"test content"
+    filename = "test.txt"
+
+    mock_response = files_pb2.File(
+        id="file-123",
+        filename=filename,
+        size=len(data),
+    )
+
+    def consume_chunks(chunks):
+        chunk_list = list(chunks)
+        assert chunk_list[0].HasField("init")
+        assert chunk_list[0].init.expires_after == 7200
+        return mock_response
+
+    mock_stub.UploadFile.side_effect = consume_chunks
+
+    result = client_with_mock_stub.files.upload(data, filename=filename, expires_after=7200)
+    assert result.id == "file-123"
+
+
+def test_upload_with_expires_after_timedelta(client_with_mock_stub: Client, mock_stub):
+    """Test uploading a file with expires_after as timedelta."""
+    data = b"test content"
+    filename = "test.txt"
+
+    mock_response = files_pb2.File(
+        id="file-123",
+        filename=filename,
+        size=len(data),
+    )
+
+    def consume_chunks(chunks):
+        chunk_list = list(chunks)
+        assert chunk_list[0].HasField("init")
+        assert chunk_list[0].init.expires_after == 86400
+        return mock_response
+
+    mock_stub.UploadFile.side_effect = consume_chunks
+
+    result = client_with_mock_stub.files.upload(data, filename=filename, expires_after=datetime.timedelta(days=1))
+    assert result.id == "file-123"


### PR DESCRIPTION
- Add optional `expires_after` parameter to `client.files.upload()` (sync and async). Accepts an `int` (seconds) or `datetime.timedelta`; the file is auto-deleted after the duration.
- **BREAKING:** Remove `team_id` from `File` responses (`upload`, `list`, `get`). The same value is available via `client.auth.get_api_key_info().team_id`.