### PR TITLE
Add `cost_usd` property to image and video responses

### DIFF
--- a/examples/aio/video_extension.py
+++ b/examples/aio/video_extension.py
@@ -46,9 +46,11 @@ async def main(argv: Sequence[str]) -> None:
             print(f"Respects moderation: {response.respect_moderation}")
             if response.respect_moderation:
                 print(f"Video URL: {response.url}")
+                print(f"Duration: {response.duration}s")
             else:
                 print("Video URL not returned due to moderation.")
-            print(f"Duration: {response.duration}s")
+            if response.cost_usd is not None:
+                print(f"Cost in USD: ${response.cost_usd:.4f}")
 
             # Chain extensions: use the returned URL as the next input video.
             if response.respect_moderation:

--- a/examples/aio/video_generation.py
+++ b/examples/aio/video_generation.py
@@ -71,9 +71,11 @@ async def main(argv: Sequence[str]) -> None:
             print(f"Respects moderation: {response.respect_moderation}")
             if response.respect_moderation:
                 print(f"Video URL: {response.url}")
+                print(f"Duration: {response.duration}s")
             else:
                 print("Video URL not returned due to moderation.")
-            print(f"Duration: {response.duration}s")
+            if response.cost_usd is not None:
+                print(f"Cost in USD: ${response.cost_usd:.4f}")
 
             # Chain edits: use the returned URL as the next input video.
             if response.respect_moderation:

--- a/examples/sync/video_extension.py
+++ b/examples/sync/video_extension.py
@@ -45,9 +45,11 @@ def main(argv: Sequence[str]) -> None:
             print(f"Respects moderation: {response.respect_moderation}")
             if response.respect_moderation:
                 print(f"Video URL: {response.url}")
+                print(f"Duration: {response.duration}s")
             else:
                 print("Video URL not returned due to moderation.")
-            print(f"Duration: {response.duration}s")
+            if response.cost_usd is not None:
+                print(f"Cost in USD: ${response.cost_usd:.4f}")
 
             # Chain extensions: use the returned URL as the next input video.
             if response.respect_moderation:

--- a/examples/sync/video_generation.py
+++ b/examples/sync/video_generation.py
@@ -70,9 +70,11 @@ def main(argv: Sequence[str]) -> None:
             print(f"Respects moderation: {response.respect_moderation}")
             if response.respect_moderation:
                 print(f"Video URL: {response.url}")
+                print(f"Duration: {response.duration}s")
             else:
                 print("Video URL not returned due to moderation.")
-            print(f"Duration: {response.duration}s")
+            if response.cost_usd is not None:
+                print(f"Cost in USD: ${response.cost_usd:.4f}")
 
             # Chain edits: use the returned URL as the next input video.
             if response.respect_moderation:

--- a/src/xai_sdk/chat.py
+++ b/src/xai_sdk/chat.py
@@ -527,6 +527,8 @@ class BaseChat(ProtoDecorator[chat_pb2.GetCompletionsRequest]):
         attributes["gen_ai.usage.cached_prompt_text_tokens"] = response.usage.cached_prompt_text_tokens
         attributes["gen_ai.usage.prompt_text_tokens"] = response.usage.prompt_text_tokens
         attributes["gen_ai.usage.prompt_image_tokens"] = response.usage.prompt_image_tokens
+        if response.usage.HasField("cost_in_usd_ticks"):
+            attributes["gen_ai.usage.cost_in_usd_ticks"] = response.usage.cost_in_usd_ticks
         attributes["gen_ai.response.system_fingerprint"] = response.system_fingerprint
 
         # Only finish reasons are different for each response.

--- a/src/xai_sdk/image.py
+++ b/src/xai_sdk/image.py
@@ -1,9 +1,10 @@
 import base64
 import warnings
-from typing import Any, Sequence, Union
+from typing import Any, Optional, Sequence, Union
 
 import grpc
 
+from .cost import cost_usd_from_usage
 from .meta import ProtoDecorator
 from .proto import image_pb2, image_pb2_grpc, usage_pb2
 from .telemetry import should_disable_sensitive_attributes
@@ -60,6 +61,11 @@ class BaseImageResponse(ProtoDecorator[image_pb2.ImageResponse]):
     def usage(self) -> usage_pb2.SamplingUsage:
         """Token and tool usage for this request."""
         return self._proto.usage
+
+    @property
+    def cost_usd(self) -> Optional[float]:
+        """Cost of the request in USD, or None if the server did not report it."""
+        return cost_usd_from_usage(self._proto.usage)
 
     @property
     def prompt(self) -> str:
@@ -212,6 +218,8 @@ def _make_span_response_attributes(
         attributes["gen_ai.usage.cached_prompt_text_tokens"] = usage.cached_prompt_text_tokens
         attributes["gen_ai.usage.prompt_text_tokens"] = usage.prompt_text_tokens
         attributes["gen_ai.usage.prompt_image_tokens"] = usage.prompt_image_tokens
+        if usage.HasField("cost_in_usd_ticks"):
+            attributes["gen_ai.usage.cost_in_usd_ticks"] = usage.cost_in_usd_ticks
 
     attributes["gen_ai.response.image.format"] = (
         image_pb2.ImageFormat.Name(request.format).removeprefix("IMG_FORMAT_").lower()

--- a/src/xai_sdk/video.py
+++ b/src/xai_sdk/video.py
@@ -3,6 +3,7 @@ from typing import Any, Optional, Sequence, Union
 
 import grpc
 
+from .cost import cost_usd_from_usage
 from .meta import ProtoDecorator
 from .proto import image_pb2, usage_pb2, video_pb2, video_pb2_grpc
 from .telemetry import should_disable_sensitive_attributes
@@ -57,6 +58,11 @@ class VideoResponse(ProtoDecorator[video_pb2.VideoResponse]):
     def usage(self) -> usage_pb2.SamplingUsage:
         """Token and tool usage for this request."""
         return self._proto.usage
+
+    @property
+    def cost_usd(self) -> Optional[float]:
+        """Cost of the request in USD, or None if the server did not report it."""
+        return cost_usd_from_usage(self._proto.usage)
 
     @property
     def respect_moderation(self) -> bool:
@@ -170,6 +176,8 @@ def _make_span_response_attributes(request: video_pb2.GenerateVideoRequest, resp
     attributes["gen_ai.usage.cached_prompt_text_tokens"] = usage.cached_prompt_text_tokens
     attributes["gen_ai.usage.prompt_text_tokens"] = usage.prompt_text_tokens
     attributes["gen_ai.usage.prompt_image_tokens"] = usage.prompt_image_tokens
+    if usage.HasField("cost_in_usd_ticks"):
+        attributes["gen_ai.usage.cost_in_usd_ticks"] = usage.cost_in_usd_ticks
 
     attributes["gen_ai.response.0.video.respect_moderation"] = response.respect_moderation
     if response._video.url:
@@ -237,6 +245,8 @@ def _make_extend_span_response_attributes(
     attributes["gen_ai.usage.cached_prompt_text_tokens"] = usage.cached_prompt_text_tokens
     attributes["gen_ai.usage.prompt_text_tokens"] = usage.prompt_text_tokens
     attributes["gen_ai.usage.prompt_image_tokens"] = usage.prompt_image_tokens
+    if usage.HasField("cost_in_usd_ticks"):
+        attributes["gen_ai.usage.cost_in_usd_ticks"] = usage.cost_in_usd_ticks
 
     attributes["gen_ai.response.0.video.respect_moderation"] = response.respect_moderation
     if response._video.url:

--- a/tests/aio/chat_test.py
+++ b/tests/aio/chat_test.py
@@ -25,7 +25,8 @@ from xai_sdk.chat import (
     tool_result,
     user,
 )
-from xai_sdk.proto import chat_pb2, image_pb2, sample_pb2
+from xai_sdk.cost import USD_PER_TICK
+from xai_sdk.proto import chat_pb2, image_pb2, sample_pb2, usage_pb2
 from xai_sdk.search import SearchParameters, news_source, rss_source, web_source, x_source
 from xai_sdk.tools import code_execution, web_search, x_search
 
@@ -1855,3 +1856,17 @@ def test_chat_create_with_include_output(client: AsyncClient):
         chat_pb2.IncludeOption.INCLUDE_OPTION_INLINE_CITATIONS,
         chat_pb2.IncludeOption.INCLUDE_OPTION_VERBOSE_STREAMING,
     ]
+
+
+def test_chat_response_cost_usd_returns_dollars_when_set():
+    proto = chat_pb2.GetChatCompletionResponse(
+        usage=usage_pb2.SamplingUsage(cost_in_usd_ticks=12345),
+    )
+    assert Response(proto, index=0).cost_usd == 12345 * USD_PER_TICK
+
+
+def test_chat_response_cost_usd_returns_none_when_unset():
+    proto = chat_pb2.GetChatCompletionResponse(
+        usage=usage_pb2.SamplingUsage(),
+    )
+    assert Response(proto, index=0).cost_usd is None

--- a/tests/aio/image_test.py
+++ b/tests/aio/image_test.py
@@ -5,8 +5,9 @@ import pytest_asyncio
 from opentelemetry.trace import SpanKind
 
 from xai_sdk import AsyncClient
-from xai_sdk.image import ImageFormat
-from xai_sdk.proto import batch_pb2, image_pb2
+from xai_sdk.cost import USD_PER_TICK
+from xai_sdk.image import BaseImageResponse, ImageFormat
+from xai_sdk.proto import batch_pb2, image_pb2, usage_pb2
 
 from .. import server
 
@@ -367,3 +368,19 @@ async def test_create_rejects_both_image_fields(client: AsyncClient):
             image_url="https://example.com/image.jpg",
             image_urls=["https://example.com/image1.jpg"],
         )
+
+
+def test_image_response_cost_usd_returns_dollars_when_set():
+    proto = image_pb2.ImageResponse(
+        images=[image_pb2.GeneratedImage(url="https://example.com/i.png")],
+        usage=usage_pb2.SamplingUsage(cost_in_usd_ticks=12345),
+    )
+    assert BaseImageResponse(proto, 0).cost_usd == 12345 * USD_PER_TICK
+
+
+def test_image_response_cost_usd_returns_none_when_unset():
+    proto = image_pb2.ImageResponse(
+        images=[image_pb2.GeneratedImage(url="https://example.com/i.png")],
+        usage=usage_pb2.SamplingUsage(),
+    )
+    assert BaseImageResponse(proto, 0).cost_usd is None

--- a/tests/aio/video_test.py
+++ b/tests/aio/video_test.py
@@ -6,8 +6,9 @@ import pytest_asyncio
 from opentelemetry.trace import SpanKind
 
 from xai_sdk import AsyncClient
-from xai_sdk.proto import batch_pb2, deferred_pb2, image_pb2, video_pb2
-from xai_sdk.video import VideoGenerationError
+from xai_sdk.cost import USD_PER_TICK
+from xai_sdk.proto import batch_pb2, deferred_pb2, image_pb2, usage_pb2, video_pb2
+from xai_sdk.video import VideoGenerationError, VideoResponse
 
 from .. import server
 
@@ -520,3 +521,19 @@ async def test_extend_warns_on_unknown_status_then_resolves(client: AsyncClient)
     assert response.url == "https://example.com/extended.mp4"
     assert len(w) == 1
     assert "Encountered unknown status: 999 whilst waiting for video extension." in str(w[0].message)
+
+
+def test_video_response_cost_usd_returns_dollars_when_set():
+    proto = video_pb2.VideoResponse(
+        video=video_pb2.GeneratedVideo(url="https://example.com/v.mp4", duration=5),
+        usage=usage_pb2.SamplingUsage(cost_in_usd_ticks=12345),
+    )
+    assert VideoResponse(proto).cost_usd == 12345 * USD_PER_TICK
+
+
+def test_video_response_cost_usd_returns_none_when_unset():
+    proto = video_pb2.VideoResponse(
+        video=video_pb2.GeneratedVideo(url="https://example.com/v.mp4", duration=5),
+        usage=usage_pb2.SamplingUsage(),
+    )
+    assert VideoResponse(proto).cost_usd is None

--- a/tests/sync/chat_test.py
+++ b/tests/sync/chat_test.py
@@ -25,7 +25,8 @@ from xai_sdk.chat import (
     tool_result,
     user,
 )
-from xai_sdk.proto import chat_pb2, image_pb2, sample_pb2
+from xai_sdk.cost import USD_PER_TICK
+from xai_sdk.proto import chat_pb2, image_pb2, sample_pb2, usage_pb2
 from xai_sdk.proto import documents_pb2 as _documents_pb2
 from xai_sdk.search import SearchParameters, news_source, rss_source, web_source, x_source
 from xai_sdk.tools import code_execution, collections_search, mcp, web_search, x_search
@@ -1978,3 +1979,17 @@ def test_chat_create_with_include_output(client: Client):
         chat_pb2.IncludeOption.INCLUDE_OPTION_INLINE_CITATIONS,
         chat_pb2.IncludeOption.INCLUDE_OPTION_VERBOSE_STREAMING,
     ]
+
+
+def test_chat_response_cost_usd_returns_dollars_when_set():
+    proto = chat_pb2.GetChatCompletionResponse(
+        usage=usage_pb2.SamplingUsage(cost_in_usd_ticks=12345),
+    )
+    assert Response(proto, index=0).cost_usd == 12345 * USD_PER_TICK
+
+
+def test_chat_response_cost_usd_returns_none_when_unset():
+    proto = chat_pb2.GetChatCompletionResponse(
+        usage=usage_pb2.SamplingUsage(),
+    )
+    assert Response(proto, index=0).cost_usd is None

--- a/tests/sync/image_test.py
+++ b/tests/sync/image_test.py
@@ -4,8 +4,9 @@ import pytest
 from opentelemetry.trace import SpanKind
 
 from xai_sdk import Client
-from xai_sdk.image import ImageFormat
-from xai_sdk.proto import batch_pb2, image_pb2
+from xai_sdk.cost import USD_PER_TICK
+from xai_sdk.image import BaseImageResponse, ImageFormat
+from xai_sdk.proto import batch_pb2, image_pb2, usage_pb2
 
 from .. import server
 
@@ -368,3 +369,19 @@ def test_create_rejects_both_image_fields(client: Client):
             image_url="https://example.com/image.jpg",
             image_urls=["https://example.com/image1.jpg"],
         )
+
+
+def test_image_response_cost_usd_returns_dollars_when_set():
+    proto = image_pb2.ImageResponse(
+        images=[image_pb2.GeneratedImage(url="https://example.com/i.png")],
+        usage=usage_pb2.SamplingUsage(cost_in_usd_ticks=12345),
+    )
+    assert BaseImageResponse(proto, 0).cost_usd == 12345 * USD_PER_TICK
+
+
+def test_image_response_cost_usd_returns_none_when_unset():
+    proto = image_pb2.ImageResponse(
+        images=[image_pb2.GeneratedImage(url="https://example.com/i.png")],
+        usage=usage_pb2.SamplingUsage(),
+    )
+    assert BaseImageResponse(proto, 0).cost_usd is None

--- a/tests/sync/video_test.py
+++ b/tests/sync/video_test.py
@@ -5,8 +5,9 @@ import pytest
 from opentelemetry.trace import SpanKind
 
 from xai_sdk import Client
-from xai_sdk.proto import batch_pb2, deferred_pb2, image_pb2, video_pb2
-from xai_sdk.video import VideoGenerationError
+from xai_sdk.cost import USD_PER_TICK
+from xai_sdk.proto import batch_pb2, deferred_pb2, image_pb2, usage_pb2, video_pb2
+from xai_sdk.video import VideoGenerationError, VideoResponse
 
 from .. import server
 
@@ -498,3 +499,19 @@ def test_extend_warns_on_unknown_status_then_resolves(client: Client):
     assert response.url == "https://example.com/extended.mp4"
     assert len(w) == 1
     assert "Encountered unknown status: 999 whilst waiting for video extension." in str(w[0].message)
+
+
+def test_video_response_cost_usd_returns_dollars_when_set():
+    proto = video_pb2.VideoResponse(
+        video=video_pb2.GeneratedVideo(url="https://example.com/v.mp4", duration=5),
+        usage=usage_pb2.SamplingUsage(cost_in_usd_ticks=12345),
+    )
+    assert VideoResponse(proto).cost_usd == 12345 * USD_PER_TICK
+
+
+def test_video_response_cost_usd_returns_none_when_unset():
+    proto = video_pb2.VideoResponse(
+        video=video_pb2.GeneratedVideo(url="https://example.com/v.mp4", duration=5),
+        usage=usage_pb2.SamplingUsage(),
+    )
+    assert VideoResponse(proto).cost_usd is None


### PR DESCRIPTION
Add `cost_usd` property to image and video responses, allowing users to see the exact amount they were charged for a given inference call for image and video generation/edits etc