### PR TITLE
fix: tighten file upload consistency

### DIFF
--- a/src/xai_sdk/aio/files.py
+++ b/src/xai_sdk/aio/files.py
@@ -145,7 +145,7 @@ class Client(BaseClient):
             res = await self._stub.UploadFile(chunks)
             if not should_disable_sensitive_attributes():
                 span.set_attribute("file.id", res.id)
-                span.set_attribute("file.filename", res.filename)
+                span.set_attribute("file.name", res.filename)
             return res
 
     async def batch_upload(
@@ -209,6 +209,8 @@ class Client(BaseClient):
         """
         if len(files) == 0:
             raise ValueError("files cannot be empty - please provide at least one file to upload")
+        if batch_size < 1:
+            raise ValueError("batch_size must be at least 1")
 
         semaphore = Semaphore(batch_size)
         results: dict[int, Union[files_pb2.File, BaseException]] = {}

--- a/src/xai_sdk/sync/files.py
+++ b/src/xai_sdk/sync/files.py
@@ -208,6 +208,8 @@ class Client(BaseClient):
         """
         if len(files) == 0:
             raise ValueError("files cannot be empty - please provide at least one file to upload")
+        if batch_size < 1:
+            raise ValueError("batch_size must be at least 1")
 
         results: dict[int, Union[files_pb2.File, BaseException]] = {}
 

--- a/tests/aio/files_test.py
+++ b/tests/aio/files_test.py
@@ -718,6 +718,16 @@ async def test_batch_upload_empty_list(client_with_mock_stub: AsyncClient):
         await client_with_mock_stub.files.batch_upload([])
 
 
+@pytest.mark.asyncio
+async def test_batch_upload_invalid_batch_size(client_with_mock_stub: AsyncClient):
+    """Test batch upload rejects non-positive batch sizes."""
+    with pytest.raises(ValueError, match="batch_size must be at least 1"):
+        await client_with_mock_stub.files.batch_upload(["file.txt"], batch_size=0)
+
+    with pytest.raises(ValueError, match="batch_size must be at least 1"):
+        await client_with_mock_stub.files.batch_upload(["file.txt"], batch_size=-1)
+
+
 @mock.patch("xai_sdk.aio.files.tracer")
 @pytest.mark.asyncio
 async def test_upload_creates_span_with_correct_attributes(
@@ -745,7 +755,7 @@ async def test_upload_creates_span_with_correct_attributes(
     )
 
     mock_span.set_attribute.assert_any_call("file.id", result.id)
-    mock_span.set_attribute.assert_any_call("file.filename", result.filename)
+    mock_span.set_attribute.assert_any_call("file.name", result.filename)
 
 
 @mock.patch("xai_sdk.aio.files.tracer")

--- a/tests/sync/files_test.py
+++ b/tests/sync/files_test.py
@@ -665,6 +665,15 @@ def test_batch_upload_empty_list(client_with_mock_stub: Client):
         client_with_mock_stub.files.batch_upload([])
 
 
+def test_batch_upload_invalid_batch_size(client_with_mock_stub: Client):
+    """Test batch upload rejects non-positive batch sizes."""
+    with pytest.raises(ValueError, match="batch_size must be at least 1"):
+        client_with_mock_stub.files.batch_upload(["file.txt"], batch_size=0)
+
+    with pytest.raises(ValueError, match="batch_size must be at least 1"):
+        client_with_mock_stub.files.batch_upload(["file.txt"], batch_size=-1)
+
+
 @mock.patch("xai_sdk.sync.files.tracer")
 def test_upload_creates_span_with_correct_attributes(
     mock_tracer: mock.MagicMock, client_with_mock_stub: Client, mock_stub


### PR DESCRIPTION
## Summary
- Align async file upload telemetry with sync upload by emitting `file.name` instead of `file.filename`
- Validate sync and async `batch_upload` reject `batch_size < 1` before creating workers/semaphores
- Add sync and async regression tests for invalid batch sizes and update the async telemetry assertion

## Tests
- `uv run pytest tests/aio/files_test.py -q`
- `uv run pytest tests/sync/files_test.py tests/aio/files_test.py -q`
- `uv run ruff check src/xai_sdk/sync/files.py src/xai_sdk/aio/files.py tests/sync/files_test.py tests/aio/files_test.py`