### PR TITLE
Bump version to 1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Changelog
 
 ## [Unreleased]
+
+## [v1.14.0]
+### Added
+- **Image Search**: Added `enable_image_search` parameter to `web_search()` to return image results that can be embedded in responses
+
+## [v1.13.0]
 ### Added
 - **Batch Video Extension**: Added `video.prepare_extension()` to sync and async clients for preparing video extension requests for the Batch API
-- **Image Search**: Added `enable_image_search` parameter to `web_search()` to return image results that can be embedded in responses
 
 ## [v1.12.0](https://github.com/xai-org/xai-sdk-python/releases/tag/v1.12.0) - 2026-04-29
 ### Added

--- a/src/xai_sdk/__about__.py
+++ b/src/xai_sdk/__about__.py
@@ -3,4 +3,4 @@
 # To change the version, do so using `uv run hatch version <new-version>`
 # or `uv run hatch version <patch|minor|major>` to bump the patch/minor/major version respectively.
 # See https://hatch.pypa.io/latest/version/#updating for more details.
-__version__ = "1.12.2"
+__version__ = "1.14.0"


### PR DESCRIPTION
## Summary

Bumps the SDK version from 1.13.0 to 1.14.0 (minor release).

This release includes the new `enable_image_search` parameter for the `web_search` tool.

### Changes
- Bumped version in `__about__.py`
- Updated CHANGELOG:
  - Added `## [v1.14.0]` section with the Image Search feature
  - Added `## [v1.13.0]` section (previously missing) for the Batch Video Extension
  - Cleaned up `[Unreleased]`

This PR follows the standard version bump process for a minor release.