### PR TITLE
Add public file URLs and list filtering to the files client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Added
 - **Imagine File Storage**: Image and video generation (sync and async) now accept a `storage_options` parameter to persist generated assets to the Files API. It takes a dict with a required `filename` and optional `expires_after` (an `int` in seconds or a `datetime.timedelta`) and `public_url` (`True` to create a public URL with default expiry, or `{"expires_after": <seconds>}` for an independent URL expiry). Image and video responses expose new `file_output`, `storage_error`, `public_url`, and `public_url_error` properties.
 - **File-ID Inputs for Generation**: Image and video generation now accept Files API `file_id` references as inputs alongside URLs/base64 — `image_file_id` / `image_file_ids` for `image.sample()` / `image.sample_batch()`, and `image_file_id` / `video_file_id` / `reference_image_file_ids` for `video.generate()` / `video.extend()` (and the batch `prepare` helpers). URL and file-ID lists may be mixed in the same multi-image request (file IDs are sent first).
+- **Public File URLs**: Added `client.files.create_public_url()` and `client.files.revoke_public_url()` (sync and async) to create and revoke publicly shareable, unauthenticated URLs for stored files. `create_public_url()` accepts an optional `expires_after` (an `int` in seconds or a `datetime.timedelta`).
+- **Files List Filter**: `client.files.list()` (sync and async) now accepts an optional `filter` parameter to narrow results server-side by fields such as `content_type`, `size_bytes`, `created_at`, `upload_status`, and `public_url` (e.g. `filter='public_url != null'`).
 
 ## [v1.14.0]
 ### Added

--- a/src/xai_sdk/aio/files.py
+++ b/src/xai_sdk/aio/files.py
@@ -15,6 +15,7 @@ from ..files import (
     _async_chunk_file_data,
     _async_chunk_file_from_fileobj,
     _async_chunk_file_from_path,
+    _expires_after_to_seconds,
     _order_to_pb,
     _sort_by_to_pb,
 )
@@ -236,6 +237,7 @@ class Client(BaseClient):
         order: Optional[Order] = None,
         sort_by: Optional[SortBy] = None,
         pagination_token: Optional[str] = None,
+        filter: Optional[str] = None,  # noqa: A002
     ) -> files_pb2.ListFilesResponse:
         """List files asynchronously.
 
@@ -244,6 +246,18 @@ class Client(BaseClient):
             order: Sort order for the files. Either "asc" (ascending) or "desc" (descending).
             sort_by: Field to sort by. Either "created_at", "filename", or "size".
             pagination_token: Token for fetching the next page of results.
+            filter: Optional filter expression to narrow down results.
+                Supported fields: file_id, name (or file_name), size_bytes,
+                content_type, created_at, expires_at, upload_status,
+                user_defined_id, public_url, public_url_expires_at.
+                Operators: =, !=, >, >=, <, <=, AND, OR, NOT. Use ``null`` to
+                match unset fields. Examples::
+
+                    filter='content_type = "application/pdf"'
+                    filter='name = "report.pdf"'
+                    filter='size_bytes > 1048576'  # larger than 1 MiB
+                    filter='public_url != null'  # only files with a public URL
+                    filter='content_type = "image/png" AND created_at > "2026-03-15T00:00:00Z"'
 
         Returns:
             A ListFilesResponse containing the list of files and optional pagination token.
@@ -258,6 +272,8 @@ class Client(BaseClient):
             request.sort_by = _sort_by_to_pb(sort_by)
         if pagination_token is not None:
             request.pagination_token = pagination_token
+        if filter is not None and filter != "":
+            request.filter = filter
 
         return await self._stub.ListFiles(request)
 
@@ -317,3 +333,66 @@ class Client(BaseClient):
             content_parts.append(chunk.data)
 
         return b"".join(content_parts)
+
+    async def create_public_url(
+        self,
+        file_id: str,
+        *,
+        expires_after: Optional[Union[datetime.timedelta, int]] = None,
+    ) -> files_pb2.CreatePublicUrlResponse:
+        """Create a publicly shareable, unauthenticated URL for a file.
+
+        The returned URL can be shared with anyone and does not require
+        an API key to access. Only images, videos, and PDFs can be made
+        public. A file can have at most one public URL at a time; calling
+        this on a file that already has a public URL returns the existing
+        URL. To update the expiry, call again with a new ``expires_after``
+        value.
+
+        **Public URL expiry behavior:**
+
+        - If ``expires_after`` is set, the public URL expires that many
+          seconds from now, independently of the file's own TTL.
+        - If ``expires_after`` is omitted and the file has a TTL
+          (``expires_after`` was set at upload), the public URL
+          automatically inherits the file's expiry -- it will expire at
+          the same time as the file.
+        - If ``expires_after`` is omitted and the file has no TTL, the
+          public URL remains valid indefinitely (until explicitly revoked
+          or the file is deleted).
+
+        Args:
+            file_id: The ID of the file to create a public URL for.
+            expires_after: Seconds (or ``timedelta``) until the public URL expires.
+                If omitted, the public URL inherits the file's TTL, or
+                remains valid indefinitely if the file has no TTL.
+
+        Returns:
+            A ``CreatePublicUrlResponse`` containing ``public_url`` and optional ``expires_at``.
+        """
+        request = files_pb2.CreatePublicUrlRequest(
+            file_id=file_id,
+            expires_after=_expires_after_to_seconds(expires_after),
+        )
+        return await self._stub.CreatePublicUrl(request)
+
+    async def revoke_public_url(self, file_id: str) -> files_pb2.RevokePublicUrlResponse:
+        """Revoke the public URL for a file.
+
+        After revocation the URL is no longer accessible. The original
+        file remains available via authenticated endpoints. Succeeds
+        even if the file has no public URL (``revoked`` will be ``False``).
+
+        Args:
+            file_id: The ID of the file whose public URL to revoke.
+
+        Returns:
+            A ``RevokePublicUrlResponse`` with:
+            - ``file_id``: The file ID acted upon.
+            - ``revoked``: ``True`` if a public URL was actually revoked,
+              ``False`` if the file had no active public URL (no-op).
+            - ``public_url``: The URL that was revoked (only present when
+              ``revoked`` is ``True``).
+        """
+        request = files_pb2.RevokePublicUrlRequest(file_id=file_id)
+        return await self._stub.RevokePublicUrl(request)

--- a/src/xai_sdk/sync/files.py
+++ b/src/xai_sdk/sync/files.py
@@ -14,6 +14,7 @@ from ..files import (
     _chunk_file_data,
     _chunk_file_from_fileobj,
     _chunk_file_from_path,
+    _expires_after_to_seconds,
     _order_to_pb,
     _sort_by_to_pb,
 )
@@ -237,6 +238,7 @@ class Client(BaseClient):
         order: Optional[Order] = None,
         sort_by: Optional[SortBy] = None,
         pagination_token: Optional[str] = None,
+        filter: Optional[str] = None,  # noqa: A002
     ) -> files_pb2.ListFilesResponse:
         """List files.
 
@@ -245,6 +247,18 @@ class Client(BaseClient):
             order: Sort order for the files. Either "asc" (ascending) or "desc" (descending).
             sort_by: Field to sort by. Either "created_at", "filename", or "size".
             pagination_token: Token for fetching the next page of results.
+            filter: Optional filter expression to narrow down results.
+                Supported fields: file_id, name (or file_name), size_bytes,
+                content_type, created_at, expires_at, upload_status,
+                user_defined_id, public_url, public_url_expires_at.
+                Operators: =, !=, >, >=, <, <=, AND, OR, NOT. Use ``null`` to
+                match unset fields. Examples::
+
+                    filter='content_type = "application/pdf"'
+                    filter='name = "report.pdf"'
+                    filter='size_bytes > 1048576'  # larger than 1 MiB
+                    filter='public_url != null'  # only files with a public URL
+                    filter='content_type = "image/png" AND created_at > "2026-03-15T00:00:00Z"'
 
         Returns:
             A ListFilesResponse containing the list of files and optional pagination token.
@@ -259,6 +273,8 @@ class Client(BaseClient):
             request.sort_by = _sort_by_to_pb(sort_by)
         if pagination_token is not None:
             request.pagination_token = pagination_token
+        if filter is not None and filter != "":
+            request.filter = filter
 
         return self._stub.ListFiles(request)
 
@@ -318,3 +334,66 @@ class Client(BaseClient):
             content_parts.append(chunk.data)
 
         return b"".join(content_parts)
+
+    def create_public_url(
+        self,
+        file_id: str,
+        *,
+        expires_after: Optional[Union[datetime.timedelta, int]] = None,
+    ) -> files_pb2.CreatePublicUrlResponse:
+        """Create a publicly shareable, unauthenticated URL for a file.
+
+        The returned URL can be shared with anyone and does not require
+        an API key to access. Only images, videos, and PDFs can be made
+        public. A file can have at most one public URL at a time; calling
+        this on a file that already has a public URL returns the existing
+        URL. To update the expiry, call again with a new ``expires_after``
+        value.
+
+        **Public URL expiry behavior:**
+
+        - If ``expires_after`` is set, the public URL expires that many
+          seconds from now, independently of the file's own TTL.
+        - If ``expires_after`` is omitted and the file has a TTL
+          (``expires_after`` was set at upload), the public URL
+          automatically inherits the file's expiry -- it will expire at
+          the same time as the file.
+        - If ``expires_after`` is omitted and the file has no TTL, the
+          public URL remains valid indefinitely (until explicitly revoked
+          or the file is deleted).
+
+        Args:
+            file_id: The ID of the file to create a public URL for.
+            expires_after: Seconds (or ``timedelta``) until the public URL expires.
+                If omitted, the public URL inherits the file's TTL, or
+                remains valid indefinitely if the file has no TTL.
+
+        Returns:
+            A ``CreatePublicUrlResponse`` containing ``public_url`` and optional ``expires_at``.
+        """
+        request = files_pb2.CreatePublicUrlRequest(
+            file_id=file_id,
+            expires_after=_expires_after_to_seconds(expires_after),
+        )
+        return self._stub.CreatePublicUrl(request)
+
+    def revoke_public_url(self, file_id: str) -> files_pb2.RevokePublicUrlResponse:
+        """Revoke the public URL for a file.
+
+        After revocation the URL is no longer accessible. The original
+        file remains available via authenticated endpoints. Succeeds
+        even if the file has no public URL (``revoked`` will be ``False``).
+
+        Args:
+            file_id: The ID of the file whose public URL to revoke.
+
+        Returns:
+            A ``RevokePublicUrlResponse`` with:
+            - ``file_id``: The file ID acted upon.
+            - ``revoked``: ``True`` if a public URL was actually revoked,
+              ``False`` if the file had no active public URL (no-op).
+            - ``public_url``: The URL that was revoked (only present when
+              ``revoked`` is ``True``).
+        """
+        request = files_pb2.RevokePublicUrlRequest(file_id=file_id)
+        return self._stub.RevokePublicUrl(request)

--- a/tests/aio/files_test.py
+++ b/tests/aio/files_test.py
@@ -299,6 +299,37 @@ async def test_list_files_with_sort_by(client_with_mock_stub: AsyncClient, mock_
 
 
 @pytest.mark.asyncio
+async def test_list_files_with_filter(client_with_mock_stub: AsyncClient, mock_stub):
+    """Test listing files with an filter expression asynchronously."""
+
+    async def async_return():
+        return files_pb2.ListFilesResponse(data=[])
+
+    mock_stub.ListFiles.return_value = async_return()
+
+    await client_with_mock_stub.files.list(filter='content_type = "application/pdf"')
+
+    call_args = mock_stub.ListFiles.call_args[0][0]
+    assert call_args.HasField("filter")
+    assert call_args.filter == 'content_type = "application/pdf"'
+
+
+@pytest.mark.asyncio
+async def test_list_files_omits_empty_filter(client_with_mock_stub: AsyncClient, mock_stub):
+    """Test that an empty filter string is treated as unset asynchronously."""
+
+    async def async_return():
+        return files_pb2.ListFilesResponse(data=[])
+
+    mock_stub.ListFiles.return_value = async_return()
+
+    await client_with_mock_stub.files.list(filter="")
+
+    call_args = mock_stub.ListFiles.call_args[0][0]
+    assert not call_args.HasField("filter")
+
+
+@pytest.mark.asyncio
 async def test_get_file(client_with_mock_stub: AsyncClient, mock_stub):
     """Test getting file metadata asynchronously."""
     # Mock the response
@@ -828,3 +859,64 @@ async def test_upload_with_expires_after_timedelta(client_with_mock_stub: AsyncC
 
     result = await client_with_mock_stub.files.upload(data, filename=filename, expires_after=datetime.timedelta(days=1))
     assert result.id == "file-123"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "expires_after, expected_seconds",
+    [
+        (None, None),
+        (86400, 86400),
+        (datetime.timedelta(hours=12), 43200),
+    ],
+    ids=["no-expiry", "int-seconds", "timedelta"],
+)
+async def test_create_public_url(client_with_mock_stub: AsyncClient, mock_stub, expires_after, expected_seconds):
+    """Test creating a public URL with various expires_after values."""
+    mock_expires_at = timestamp_pb2.Timestamp(seconds=1720000000)
+    mock_response = files_pb2.CreatePublicUrlResponse(
+        public_url="https://example.com/files/file-123.png",
+        expires_at=mock_expires_at,
+    )
+
+    async def async_return():
+        return mock_response
+
+    mock_stub.CreatePublicUrl.return_value = async_return()
+
+    kwargs = {"expires_after": expires_after} if expires_after is not None else {}
+    result = await client_with_mock_stub.files.create_public_url("file-123", **kwargs)
+
+    call_args = mock_stub.CreatePublicUrl.call_args[0][0]
+    assert call_args.file_id == "file-123"
+    if expected_seconds is None:
+        assert not call_args.HasField("expires_after")
+    else:
+        assert call_args.expires_after == expected_seconds
+
+    assert result.public_url == "https://example.com/files/file-123.png"
+    assert result.expires_at == mock_expires_at
+
+
+@pytest.mark.asyncio
+async def test_revoke_public_url(client_with_mock_stub: AsyncClient, mock_stub):
+    """Test revoking a public URL for a file asynchronously."""
+    mock_response = files_pb2.RevokePublicUrlResponse(
+        file_id="file-123",
+        revoked=True,
+        public_url="https://example.com/files/file-123.png",
+    )
+
+    async def async_return():
+        return mock_response
+
+    mock_stub.RevokePublicUrl.return_value = async_return()
+
+    result = await client_with_mock_stub.files.revoke_public_url("file-123")
+
+    call_args = mock_stub.RevokePublicUrl.call_args[0][0]
+    assert call_args.file_id == "file-123"
+    assert isinstance(result, files_pb2.RevokePublicUrlResponse)
+    assert result.file_id == "file-123"
+    assert result.revoked is True
+    assert result.public_url == "https://example.com/files/file-123.png"

--- a/tests/sync/files_test.py
+++ b/tests/sync/files_test.py
@@ -316,6 +316,27 @@ def test_list_files_with_sort_by(client_with_mock_stub: Client, mock_stub):
     assert call_args.order == files_pb2.Ordering.ASCENDING
 
 
+def test_list_files_with_filter(client_with_mock_stub: Client, mock_stub):
+    """Test listing files with an filter expression."""
+    mock_stub.ListFiles.return_value = files_pb2.ListFilesResponse(data=[])
+
+    client_with_mock_stub.files.list(filter='content_type = "application/pdf"')
+
+    call_args = mock_stub.ListFiles.call_args[0][0]
+    assert call_args.HasField("filter")
+    assert call_args.filter == 'content_type = "application/pdf"'
+
+
+def test_list_files_omits_empty_filter(client_with_mock_stub: Client, mock_stub):
+    """Test that an empty filter string is treated as unset."""
+    mock_stub.ListFiles.return_value = files_pb2.ListFilesResponse(data=[])
+
+    client_with_mock_stub.files.list(filter="")
+
+    call_args = mock_stub.ListFiles.call_args[0][0]
+    assert not call_args.HasField("filter")
+
+
 def test_get_file(client_with_mock_stub: Client, mock_stub):
     """Test getting file metadata."""
     # Mock the response
@@ -819,3 +840,54 @@ def test_upload_with_expires_after_timedelta(client_with_mock_stub: Client, mock
 
     result = client_with_mock_stub.files.upload(data, filename=filename, expires_after=datetime.timedelta(days=1))
     assert result.id == "file-123"
+
+
+@pytest.mark.parametrize(
+    "expires_after, expected_seconds",
+    [
+        (None, None),
+        (86400, 86400),
+        (datetime.timedelta(hours=12), 43200),
+    ],
+    ids=["no-expiry", "int-seconds", "timedelta"],
+)
+def test_create_public_url(client_with_mock_stub: Client, mock_stub, expires_after, expected_seconds):
+    """Test creating a public URL with various expires_after values."""
+    mock_expires_at = timestamp_pb2.Timestamp(seconds=1720000000)
+    mock_response = files_pb2.CreatePublicUrlResponse(
+        public_url="https://example.com/files/file-123.png",
+        expires_at=mock_expires_at,
+    )
+    mock_stub.CreatePublicUrl.return_value = mock_response
+
+    kwargs = {"expires_after": expires_after} if expires_after is not None else {}
+    result = client_with_mock_stub.files.create_public_url("file-123", **kwargs)
+
+    call_args = mock_stub.CreatePublicUrl.call_args[0][0]
+    assert call_args.file_id == "file-123"
+    if expected_seconds is None:
+        assert not call_args.HasField("expires_after")
+    else:
+        assert call_args.expires_after == expected_seconds
+
+    assert result.public_url == "https://example.com/files/file-123.png"
+    assert result.expires_at == mock_expires_at
+
+
+def test_revoke_public_url(client_with_mock_stub: Client, mock_stub):
+    """Test revoking a public URL for a file."""
+    mock_response = files_pb2.RevokePublicUrlResponse(
+        file_id="file-123",
+        revoked=True,
+        public_url="https://example.com/files/file-123.png",
+    )
+    mock_stub.RevokePublicUrl.return_value = mock_response
+
+    result = client_with_mock_stub.files.revoke_public_url("file-123")
+
+    call_args = mock_stub.RevokePublicUrl.call_args[0][0]
+    assert call_args.file_id == "file-123"
+    assert isinstance(result, files_pb2.RevokePublicUrlResponse)
+    assert result.file_id == "file-123"
+    assert result.revoked is True
+    assert result.public_url == "https://example.com/files/file-123.png"


### PR DESCRIPTION
- Add `files.create_public_url()` / `files.revoke_public_url()` (sync + async) to create and revoke publicly shareable, unauthenticated URLs for stored files
- Add an optional `filter` parameter to `files.list()` (sync + async) for server-side filtering (e.g. `content_type`, `size_bytes`, `created_at`, `public_url`)
- Add unit tests covering create/revoke and the filter param across sync and aio