### PR TITLE
Add new grok imagine models to types/model.py for editor autocomplete

### DIFF
--- a/src/xai_sdk/types/model.py
+++ b/src/xai_sdk/types/model.py
@@ -42,9 +42,13 @@ ChatModel: TypeAlias = Literal[
 ImageGenerationModel: TypeAlias = Literal[
     "grok-imagine-image",
     "grok-imagine-image-pro",
+    "grok-imagine-image-quality",
 ]
 
-VideoGenerationModel: TypeAlias = Literal["grok-imagine-video"]
+VideoGenerationModel: TypeAlias = Literal[
+    "grok-imagine-video",
+    "grok-imagine-video-1.5-preview",
+]
 
 AllModels: TypeAlias = Union[
     ChatModel,


### PR DESCRIPTION
- Add recently released image/video generation models to types/model.py for editor autocomplete.
- [grok-imagine-image-quality](https://docs.x.ai/developers/models/grok-imagine-image-quality) for image generation
- [grok-imagine-video-1.5-preview](https://docs.x.ai/developers/models/grok-imagine-video-1.5-preview) for image to video generation