### PR TITLE
chore: bump version to 1.17.0

### DIFF
--- a/src/xai_sdk/__about__.py
+++ b/src/xai_sdk/__about__.py
@@ -3,4 +3,4 @@
 # To change the version, do so using `uv run hatch version <new-version>`
 # or `uv run hatch version <patch|minor|major>` to bump the patch/minor/major version respectively.
 # See https://hatch.pypa.io/latest/version/#updating for more details.
-__version__ = "1.16.0"
+__version__ = "1.17.0"


### PR DESCRIPTION
Minor version bump for the next release (1.16.0 → 1.17.0).

After merge: the auto-tag workflow creates `v1.17.0`, then the Release workflow will be dispatched on that tag.