### PR TITLE
Make version-gated proto imports statically analyzable

### DIFF
--- a/src/xai_sdk/proto/__init__.py
+++ b/src/xai_sdk/proto/__init__.py
@@ -1,8 +1,46 @@
+from typing import TYPE_CHECKING
+
 from packaging import version
 
 import google.protobuf
 
-if version.parse(google.protobuf.__version__).major == 5:
+if TYPE_CHECKING:
+    # Type checkers cannot evaluate the runtime protobuf-version gate below, so
+    # they infer a v5|v6 union across the whole SDK surface. The v5 and v6 pb2
+    # modules are structurally identical (same class sets), so pinning one arm
+    # for typing is correct; runtime behavior is unchanged by the elif/else.
+    from .v6 import (
+        auth_pb2,
+        auth_pb2_grpc,
+        batch_pb2,
+        batch_pb2_grpc,
+        chat_pb2,
+        chat_pb2_grpc,
+        collections_pb2,
+        collections_pb2_grpc,
+        deferred_pb2,
+        deferred_pb2_grpc,
+        documents_pb2,
+        documents_pb2_grpc,
+        embed_pb2,
+        embed_pb2_grpc,
+        files_pb2,
+        files_pb2_grpc,
+        image_pb2,
+        image_pb2_grpc,
+        models_pb2,
+        models_pb2_grpc,
+        sample_pb2,
+        sample_pb2_grpc,
+        shared_pb2,
+        tokenize_pb2,
+        tokenize_pb2_grpc,
+        types_pb2,
+        usage_pb2,
+        video_pb2,
+        video_pb2_grpc,
+    )
+elif version.parse(google.protobuf.__version__).major == 5:
     from .v5 import (
         auth_pb2,
         auth_pb2_grpc,


### PR DESCRIPTION
This PR was posted by claude-code using claude-opus-4-8 on behalf of David (@dsfaccini), who reviewed the approach.

## Checklist
- [x] I have read both the [CONTRIBUTING.md](CONTRIBUTING.md) and [Contributor License Agreement](CLA.md) documents. By opening this PR, David (@dsfaccini) agrees to the CLA terms.
- [x] I have created an issue (#177) describing the problem. (Opening the PR alongside it for reviewer convenience; happy to hold for maintainer alignment before merge.)
- [x] Change verified locally (see Description). Note: `src/xai_sdk/proto` is excluded from `ruff` and `pyright` in `pyproject.toml`, so CI does not lint/type-check this file; the edit is runtime-inert.
- [ ] No documentation changes needed (single-file, behavior-preserving typing change).

## Description

`src/xai_sdk/proto/__init__.py` selects between the `.v5` and `.v6` proto packages at runtime based on the installed **protobuf** major version. Static type checkers cannot evaluate this gate, so they infer each proto symbol as a **`v5 | v6` union**. Because the SDK's public API is annotated with these proto types (e.g. `xai_sdk.chat.assistant(...) -> chat_pb2.Message`), the union propagates through the entire SDK surface and produces spurious type errors in any downstream code that touches it.

This PR wraps the existing gate with a leading `if TYPE_CHECKING:` branch that pins the `.v6` pb2 modules for typing, converting the current first `if` to `elif`. Type checkers now see a single, definite arm; **runtime behavior is completely unchanged** — the `elif`/`else` chain is the original gate, so under both protobuf 5 and 6 the same modules are imported at runtime as before.

Pinning `.v6` for typing is honest because the `.v5` and `.v6` `*_pb2` stubs are **structurally identical**: all 16 `*_pb2.pyi` modules have an identical set of top-level `class` names between `.v5` and `.v6` (e.g. `chat_pb2` = 51 classes in both). Runtime correctness across protobuf majors stays guaranteed by the untouched runtime gate.

### Verification

Environment: `xai-sdk 1.14.0`, `protobuf 6.33.5`, `types-protobuf 6.32.1`; checked against [pydantic-ai](https://github.com/pydantic/pydantic-ai)'s real `models/xai.py` (which does `from xai_sdk.proto import chat_pb2, sample_pb2, usage_pb2`).

- **Astral `ty` on `models/xai.py`:** **49 → 4** diagnostics. All 45 removed are the proto `v5|v6` union cluster (e.g. `ResponseFormat.__init__`, `ToolCall.__init__`); the 4 residuals are pre-existing and unrelated (`grpc.RpcError.code/details`, an override signature, an `aclose` attribute).
- **pyright on the same file:** `0 errors` before and after. Today pyright silently resolves the gate to the first arm (`.v5`) regardless of what's installed; with this change it resolves `.v6` explicitly. No regression, just determinism.
- **Runtime unchanged:** on a protobuf-6 install, `from xai_sdk.proto import chat_pb2` still resolves to `xai_sdk.proto.v6.chat_pb2` at runtime, exactly as before. `python -m py_compile` passes; the `TYPE_CHECKING` v6 import list is byte-for-byte the same 29 names as the runtime v5/v6 branches.

This lets downstream consumers (pydantic-ai among them) type-check cleanly against the SDK's proto-typed API — they cannot fix the union from their own import site (any local pin makes it worse: 49 → 75).

## Related Issue

#177

## Type of Change
- [x] Bug fix (spurious type errors leaking to downstream consumers)
- [ ] New feature
- [ ] Documentation update
- [x] Other: type-checking ergonomics (behavior-preserving)

## Additional Notes

Minimal and self-contained — a single file, mechanical change only: add `from typing import TYPE_CHECKING` and prepend the `if TYPE_CHECKING: from .v6 import (...)` block (same name list as the runtime branches). No other files change, no runtime path altered.
