### PR TITLE
Add grok-4.5 to ChatModel

### DIFF
--- a/src/xai_sdk/types/model.py
+++ b/src/xai_sdk/types/model.py
@@ -28,6 +28,8 @@ ChatModel: TypeAlias = Literal[
     "grok-4.20-multi-agent-latest",
     "grok-4.3",
     "grok-4.3-latest",
+    "grok-4.5",
+    "grok-4.5-latest",
     "grok-code-fast-1",
     "grok-build-0.1",
     "grok-3",


### PR DESCRIPTION
## Summary
- Add `grok-4.5` and `grok-4.5-latest` to the `ChatModel` literal in `types/model.py` for IDE autocomplete.

## Test plan
- [x] Confirm the new model IDs appear in editor autocomplete for `client.chat.create(model=...)`
- [x] Sanity-check that existing `ChatModel` values are unchanged