### PR TITLE
chore: bump version to 1.17.1

### DIFF
--- a/src/xai_sdk/__about__.py
+++ b/src/xai_sdk/__about__.py
@@ -3,4 +3,4 @@
 # To change the version, do so using `uv run hatch version <new-version>`
 # or `uv run hatch version <patch|minor|major>` to bump the patch/minor/major version respectively.
 # See https://hatch.pypa.io/latest/version/#updating for more details.
-__version__ = "1.17.0"
+__version__ = "1.17.1"


### PR DESCRIPTION
## Summary
- Bump package version from `1.17.0` to `1.17.1` in `__about__.py`.

## Test plan
- [x] Confirm `__version__` is `1.17.1` in `src/xai_sdk/__about__.py`
- [x] After merge, confirm auto-tag workflow creates `v1.17.1`