### PR TITLE
Support protobuf 7 by routing major >= 6 to the v6 gencode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 authors = [{ name = "xAI", email = "support@x.ai" }]
 dependencies = [
   "grpcio>=1.72.1,<2",
-  "protobuf>=5.29.4,<7",
+  "protobuf>=5.29.4,<8",
   "googleapis-common-protos>=1.65.0,<2",
   "pydantic>=2.5.3,<3",
   "requests>=2.31.0,<3",

--- a/src/xai_sdk/proto/__init__.py
+++ b/src/xai_sdk/proto/__init__.py
@@ -34,7 +34,7 @@ if version.parse(google.protobuf.__version__).major == 5:
         video_pb2,
         video_pb2_grpc,
     )
-elif version.parse(google.protobuf.__version__).major == 6:
+elif version.parse(google.protobuf.__version__).major >= 6:
     from .v6 import (
         auth_pb2,
         auth_pb2_grpc,


### PR DESCRIPTION
## Problem

On distributions that already ship protobuf 7.x (openSUSE Tumbleweed with 7.34.2, Arch Linux with 7.35.1), importing the SDK fails:

```
ValueError: Unsupported protobuf version: 7.34.2
```

raised by the strict `major == 6` dispatch in `src/xai_sdk/proto/__init__.py`.

## Why this is safe

Per protobuf's [cross-version runtime guarantee](https://protobuf.dev/support/cross-version-runtime-guarantee), gencode is forward-compatible with newer runtimes: `ValidateProtobufRuntimeVersion` only rejects a runtime that is **older** than the linked gencode, never a newer one. So the bundled v6 stubs load and work fine on the protobuf 7 runtime — only the SDK's own dispatch was rejecting it.

## Change

- Route `major >= 6` to the v6 stubs instead of `major == 6`
- Relax the `pyproject.toml` cap from `protobuf<7` to `<8` accordingly

## Verification

Full test suite (763 tests, mock gRPC server) passes against protobuf 7.34.2 on Python 3.13 and 3.14 (run while packaging the SDK for openSUSE).