### PR TITLE
chore: bump version to 1.18.0

### DIFF
--- a/src/xai_sdk/__about__.py
+++ b/src/xai_sdk/__about__.py
@@ -3,4 +3,4 @@
 # To change the version, do so using `uv run hatch version <new-version>`
 # or `uv run hatch version <patch|minor|major>` to bump the patch/minor/major version respectively.
 # See https://hatch.pypa.io/latest/version/#updating for more details.
-__version__ = "1.17.1"
+__version__ = "1.18.0"


### PR DESCRIPTION
Bump version from 1.17.1 to 1.18.0 (minor: additive changes only) to release the current `[Unreleased]` changes, including `xhigh` reasoning effort support and `grok-4.6` in `ChatModel` (#189).

On merge, the auto-tag workflow will create `v1.18.0`; the Release workflow can then be dispatched against that tag to publish to PyPI.