### PR TITLE
Update README examples to use grok-4.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ from xai_sdk.chat import system, user
 
 client = Client()
 chat = client.chat.create(
-    model="grok-3",
+    model="grok-4.6",
     messages=[system("You are a pirate assistant.")]
 )
 
@@ -112,7 +112,7 @@ from xai_sdk.chat import system, user
 async def main():
     client = AsyncClient()
     chat = client.chat.create(
-        model="grok-3",
+        model="grok-4.6",
         messages=[system("You are a pirate assistant.")]
     )
 
@@ -138,7 +138,7 @@ from xai_sdk import Client
 from xai_sdk.chat import user
 
 client = Client()
-chat = client.chat.create(model="grok-3")
+chat = client.chat.create(model="grok-4.6")
 
 while True:
     prompt = input("You: ")
@@ -161,7 +161,7 @@ from xai_sdk import Client
 from xai_sdk.chat import image, user
 
 client = Client()
-chat = client.chat.create(model="grok-2-vision")
+chat = client.chat.create(model="grok-4.6")
 
 chat.append(
     user(
@@ -302,7 +302,7 @@ telemetry.setup_console_exporter()
 client = Client()
 
 # The call to sample will now generate a trace that you will be able to see in the console
-chat = client.chat.create(model="grok-3")
+chat = client.chat.create(model="grok-4.6")
 chat.append(user("Hello, how are you?"))
 response = chat.sample()
 print(f"Response: {response.content}")
@@ -324,7 +324,7 @@ telemetry.setup_otlp_exporter(
 client = Client()
 
 # The call to sample will now generate a trace that you will be able to see in your observability platform
-chat = client.chat.create(model="grok-3")
+chat = client.chat.create(model="grok-4.6")
 chat.append(user("Hello, how are you?"))
 response = chat.sample()
 print(f"Response: {response.content}")
@@ -510,7 +510,7 @@ from xai_sdk import Client
 from xai_sdk.chat import user
 
 client = Client()
-chat = client.chat.create(model="grok-3")
+chat = client.chat.create(model="grok-4.6")
 chat.append(user("Hello, how are you?"))
 response = chat.sample()
 


### PR DESCRIPTION
## Summary

The README code samples still referenced retired models. Per the current model lineup on [docs.x.ai](https://docs.x.ai/developers/models), `grok-4.6` is the flagship model for chat and code and is multimodal, so it also replaces the dedicated vision model:

- `model="grok-3"` → `model="grok-4.6"` (6 occurrences: quickstart, async, streaming, telemetry ×2, proto access)
- `model="grok-2-vision"` → `model="grok-4.6"` (image understanding example)

The `grok-imagine-video` references are left as-is — that is still the current video generation slug.

## Test plan

- Ran the updated image-understanding snippet (two image URLs + text) live against the API with `grok-4.6` via `xai-sdk==1.18.0`: completes with `REASON_STOP` and a sensible answer.
- Basic `grok-4.6` chat request verified live as part of the v1.18.0 release testing.