### PR TITLE
fix: bound the async image download to the same 5s as sync

### DIFF
--- a/src/xai_sdk/aio/image.py
+++ b/src/xai_sdk/aio/image.py
@@ -6,6 +6,7 @@ from opentelemetry.trace import SpanKind
 from ..client import USER_AGENT
 from ..files import StorageOptions
 from ..image import (
+    IMAGE_DOWNLOAD_TIMEOUT_SECONDS,
     BaseClient,
     BaseImageResponse,
     ImageAspectRatio,
@@ -363,6 +364,7 @@ class ImageResponse(BaseImageResponse):
                 "GET",
                 self.url,
                 headers={"User-Agent": USER_AGENT},
+                timeout=aiohttp.ClientTimeout(total=IMAGE_DOWNLOAD_TIMEOUT_SECONDS),
             ) as session:
                 session.raise_for_status()
                 return await session.read()

--- a/src/xai_sdk/image.py
+++ b/src/xai_sdk/image.py
@@ -11,6 +11,14 @@ from .proto import image_pb2, image_pb2_grpc, usage_pb2
 from .telemetry import should_disable_sensitive_attributes
 from .types import ImageAspectRatio, ImageFormat, ImageGenerationModel, ImageQuality, ImageResolution
 
+"""Seconds to wait when downloading an image returned as a URL.
+
+Shared by the sync and async `ImageResponse.image` accessors so the two
+transports cannot drift apart: `requests` has no default timeout and
+`aiohttp.request` defaults to 300s total, so each has to be told explicitly.
+"""
+IMAGE_DOWNLOAD_TIMEOUT_SECONDS = 5
+
 _IMAGE_ASPECT_RATIO_MAP: dict[ImageAspectRatio, image_pb2.ImageAspectRatio] = {
     "1:1": image_pb2.ImageAspectRatio.IMG_ASPECT_RATIO_1_1,
     "3:4": image_pb2.ImageAspectRatio.IMG_ASPECT_RATIO_3_4,

--- a/src/xai_sdk/sync/image.py
+++ b/src/xai_sdk/sync/image.py
@@ -6,6 +6,7 @@ from opentelemetry.trace import SpanKind
 from ..client import USER_AGENT
 from ..files import StorageOptions
 from ..image import (
+    IMAGE_DOWNLOAD_TIMEOUT_SECONDS,
     BaseClient,
     BaseImageResponse,
     ImageAspectRatio,
@@ -362,7 +363,7 @@ class ImageResponse(BaseImageResponse):
             response = requests.get(
                 self.url,
                 headers={"User-Agent": USER_AGENT},
-                timeout=5,  # 5 seconds
+                timeout=IMAGE_DOWNLOAD_TIMEOUT_SECONDS,
             )
             response.raise_for_status()
             return response.content

--- a/tests/aio/image_test.py
+++ b/tests/aio/image_test.py
@@ -1,6 +1,7 @@
 import datetime
 from unittest import mock
 
+import aiohttp
 import pytest
 import pytest_asyncio
 from google.protobuf import timestamp_pb2
@@ -9,6 +10,7 @@ from opentelemetry.trace import SpanKind
 from xai_sdk import AsyncClient
 from xai_sdk.cost import USD_PER_TICK
 from xai_sdk.image import (
+    IMAGE_DOWNLOAD_TIMEOUT_SECONDS,
     BaseImageResponse,
     ImageFormat,
     _make_generate_request,
@@ -46,6 +48,20 @@ async def test_url(client: AsyncClient, image_asset: bytes):
     with pytest.warns(DeprecationWarning, match="BaseImageResponse.prompt is deprecated"):
         assert response.prompt == ""
     assert image_asset == await response.image
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_url_download_uses_the_shared_timeout(client: AsyncClient, image_asset: bytes):
+    """The async download must use the same bound as the sync one. `aiohttp.request`
+    defaults to 300s total, so without an explicit timeout the two transports differ
+    by 60x for the same call."""
+    real_request = aiohttp.request
+    with mock.patch("xai_sdk.aio.image.aiohttp.request", wraps=real_request) as request:
+        response = await client.image.sample(prompt="foo", model="grok-2-image", image_format="url")
+        assert image_asset == await response.image
+
+    timeout = request.call_args.kwargs["timeout"]
+    assert timeout.total == IMAGE_DOWNLOAD_TIMEOUT_SECONDS
 
 
 @pytest.mark.asyncio(loop_scope="session")

--- a/tests/sync/image_test.py
+++ b/tests/sync/image_test.py
@@ -2,12 +2,14 @@ import datetime
 from unittest import mock
 
 import pytest
+import requests
 from google.protobuf import timestamp_pb2
 from opentelemetry.trace import SpanKind
 
 from xai_sdk import Client
 from xai_sdk.cost import USD_PER_TICK
 from xai_sdk.image import (
+    IMAGE_DOWNLOAD_TIMEOUT_SECONDS,
     BaseImageResponse,
     ImageFormat,
     _make_generate_request,
@@ -43,6 +45,16 @@ def test_url(client: Client, image_asset: bytes):
     with pytest.warns(DeprecationWarning, match="BaseImageResponse.prompt is deprecated"):
         assert response.prompt == ""
     assert image_asset == response.image
+
+
+def test_url_download_uses_the_shared_timeout(client: Client, image_asset: bytes):
+    """The URL download must be bounded. `requests` has no default timeout, so
+    omitting it would hang the caller indefinitely on a stalled connection."""
+    with mock.patch("xai_sdk.sync.image.requests.get", wraps=requests.get) as get:
+        response = client.image.sample(prompt="foo", model="grok-2-image", image_format="url")
+        assert image_asset == response.image
+
+    assert get.call_args.kwargs["timeout"] == IMAGE_DOWNLOAD_TIMEOUT_SECONDS
 
 
 def test_batch(client: Client, image_asset: bytes):


### PR DESCRIPTION
## Problem

`ImageResponse.image` downloads the image when the API returns a URL rather than base64. The two transports disagree on how long that may take:

| | call | effective timeout |
|---|---|---|
| `sync/image.py:362` | `requests.get(..., timeout=5)` | **5s** |
| `aio/image.py:362` | `aiohttp.request("GET", ...)` | **300s** |

`aiohttp.request` with no `timeout` falls back to aiohttp's default, which I confirmed against the pinned version:

```
aiohttp 3.12.12
DEFAULT_TIMEOUT = ClientTimeout(total=300, connect=None, sock_read=None, sock_connect=30, ...)
```

So the same operation is bounded 60× more loosely on the async client than the sync one already decided was right. On a stalled CDN connection, `await response.image` blocks for five minutes — in an async program, usually while holding whatever task the caller expected to be short.

## Fix

Both paths now read `IMAGE_DOWNLOAD_TIMEOUT_SECONDS` from the shared `xai_sdk.image` module instead of each carrying its own literal, so they cannot drift apart again. The sync behaviour is unchanged — it just stops hardcoding the number.

These are the only two outbound HTTP calls in the SDK (`grep` for `requests.`/`aiohttp.` across `src/xai_sdk` returns exactly these two); everything else is gRPC, so the scope really is this pair.

## Tests

One test per suite, asserting the timeout that actually reaches the transport:

- `tests/sync/image_test.py::test_url_download_uses_the_shared_timeout`
- `tests/aio/image_test.py::test_url_download_uses_the_shared_timeout`

With the two handlers reverted, the async one fails with `KeyError: 'timeout'` — no timeout was passed. The sync one passes either way, which is correct: the sync path was never the bug, and that test is there to keep it from becoming one.

## Checks

All four from CONTRIBUTING, run locally:

| check | result |
|---|---|
| `uv run ruff format --check` | 122 files already formatted |
| `uv run ruff check` | All checks passed! |
| `uv run pyright` | 0 errors, 0 warnings |
| `uv run pytest -n auto` | **824 passed** (822 before, +2 new) |