### PR TITLE
fix(chat): expose stream_batch content for every response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- `stream_batch` now materializes each chunk's content into the shared response proto before yielding, so every response (not just the first) shows accumulated content when read during streaming or in any read order.
 
 ## [v1.19.0](https://github.com/xai-org/xai-sdk-python/releases/tag/v1.19.0) - 2026-08-18
 ### Added

--- a/src/xai_sdk/aio/chat.py
+++ b/src/xai_sdk/aio/chat.py
@@ -321,6 +321,10 @@ class Chat(BaseChat):
                     first_chunk_received = True
 
                 responses[0].process_chunk(chunk)
+                # All chunk deltas for every output index accumulate in the first
+                # response's buffers; materialize them into the shared proto so
+                # every response sees current content regardless of read order.
+                responses[0]._sync_buffers_to_proto()
                 yield responses, [Chunk(chunk, i) for i in range(n)]
 
             span.set_attributes(self._make_span_response_attributes(responses))

--- a/src/xai_sdk/sync/chat.py
+++ b/src/xai_sdk/sync/chat.py
@@ -314,6 +314,10 @@ class Chat(BaseChat):
                     first_chunk_received = True
 
                 responses[0].process_chunk(chunk)
+                # All chunk deltas for every output index accumulate in the first
+                # response's buffers; materialize them into the shared proto so
+                # every response sees current content regardless of read order.
+                responses[0]._sync_buffers_to_proto()
                 yield responses, [Chunk(chunk, i) for i in range(n)]
 
             span.set_attributes(self._make_span_response_attributes(responses))

--- a/tests/aio/chat_test.py
+++ b/tests/aio/chat_test.py
@@ -137,6 +137,27 @@ async def test_streaming_batch(client):
 
 
 @pytest.mark.asyncio(loop_scope="session")
+async def test_streaming_batch_each_response_populated_during_stream(client):
+    """Reading a later response's content during the stream must show accumulated content.
+
+    Regression: stream_batch accumulated all deltas in the first response's
+    buffers and only materialized them into the shared proto when response[0]
+    was read (or the telemetry span closed). A caller streaming per-option
+    content from response[1] alone got an empty string for the whole stream.
+    """
+    chat = client.chat.create("grok-3-latest")
+    chat.append(user("test message"))
+    stream = chat.stream_batch(2)
+
+    observed = []
+    async for responses, _ in stream:
+        observed.append(responses[1].content)
+
+    assert observed
+    assert observed[-1] == "Hello, this is a test response!"
+
+
+@pytest.mark.asyncio(loop_scope="session")
 async def test_deferred(client):
     chat = client.chat.create("grok-3-latest")
     chat.append(user("test message"))

--- a/tests/sync/chat_test.py
+++ b/tests/sync/chat_test.py
@@ -126,6 +126,26 @@ def test_streaming_batch(client: Client):
     assert last_response[1].content == "Hello, this is a test response!"
 
 
+def test_streaming_batch_each_response_populated_during_stream(client: Client):
+    """Reading a later response's content during the stream must show accumulated content.
+
+    Regression: stream_batch accumulated all deltas in the first response's
+    buffers and only materialized them into the shared proto when response[0]
+    was read (or the telemetry span closed). A caller streaming per-option
+    content from response[1] alone got an empty string for the whole stream.
+    """
+    chat = client.chat.create("grok-3-latest")
+    chat.append(user("test message"))
+    stream = chat.stream_batch(2)
+
+    observed = []
+    for responses, _ in stream:
+        observed.append(responses[1].content)
+
+    assert observed
+    assert observed[-1] == "Hello, this is a test response!"
+
+
 def test_function_calling(client: Client):
     chat = client.chat.create(
         "grok-3-latest",


### PR DESCRIPTION
## Description

`stream_batch(n)` wraps all n options in `Response` objects that share one underlying proto, but only `responses[0].process_chunk(chunk)` is called for every incoming chunk. Chunk content is buffered per output index inside the first response, and only materialized into the shared proto when `responses[0].content` is read, or when the telemetry span closes.

A caller that reads `responses[i].content` for i > 0 during streaming, or before `responses[0]`, gets an empty string for the whole stream. This is the natural way to stream per-option content:

```python
async for responses, _ in chat.stream_batch(2):
    print(responses[1].content)
```

With this code `responses[1].content` is `""` on every iteration, even though the server streams the content. The fix materializes the buffered content into the shared proto after every chunk, so each response reflects the streamed content regardless of read order.

## Changes
- `src/xai_sdk/aio/chat.py`: sync content buffers to the shared proto after each chunk in `stream_batch`
- `src/xai_sdk/sync/chat.py`: same fix for the sync client
- Regression tests in `tests/aio/chat_test.py` and `tests/sync/chat_test.py` that read `responses[1].content` during the stream. They fail on the current code and pass with this change.
- Changelog entry under Unreleased.

## Type of Change
- [x] Bug fix

## Related Issue
N/A
